### PR TITLE
Added MaxWarningErrorThreshold concept

### DIFF
--- a/source/NsDepCop.Core/Implementation/Config/AnalyzerConfig.cs
+++ b/source/NsDepCop.Core/Implementation/Config/AnalyzerConfig.cs
@@ -19,16 +19,8 @@ namespace Codartis.NsDepCop.Core.Implementation.Config
         public HashSet<NamespaceDependencyRule> DisallowRules { get; }
         public Dictionary<Namespace, TypeNameSet> VisibleTypesByNamespace { get; }
         public int MaxIssueCount { get; }
-
-        public AnalyzerConfig(
-            bool isEnabled,
-            IssueKind issueKind,
-            Importance infoImportance,
-            bool childCanDependOnParentImplicitly,
-            Dictionary<NamespaceDependencyRule, TypeNameSet> allowRules,
-            HashSet<NamespaceDependencyRule> disallowRules,
-            Dictionary<Namespace, TypeNameSet> visibleTypesByNamespace,
-            int maxIssueCount)
+        public int? MaxWarningErrorThreshold { get; }
+        public AnalyzerConfig(bool isEnabled, IssueKind issueKind, Importance infoImportance, bool childCanDependOnParentImplicitly, Dictionary<NamespaceDependencyRule, TypeNameSet> allowRules, HashSet<NamespaceDependencyRule> disallowRules, Dictionary<Namespace, TypeNameSet> visibleTypesByNamespace, int maxIssueCount, int? maxWarningErrorThreshold)
         {
             IsEnabled = isEnabled;
             IssueKind = issueKind;
@@ -39,6 +31,7 @@ namespace Codartis.NsDepCop.Core.Implementation.Config
             DisallowRules = disallowRules;
             VisibleTypesByNamespace = visibleTypesByNamespace;
             MaxIssueCount = maxIssueCount;
+            MaxWarningErrorThreshold = maxWarningErrorThreshold;
         }
 
         public IEnumerable<string> ToStrings()
@@ -52,6 +45,8 @@ namespace Codartis.NsDepCop.Core.Implementation.Config
             foreach (var s in DisallowRules.ToStrings()) yield return s;
             foreach (var s in VisibleTypesByNamespace.ToStrings()) yield return s;
             yield return $"MaxIssueCount={MaxIssueCount}";
+            yield return $"MaxWarningErrorThreshold={MaxWarningErrorThreshold}";
+
         }
     }
 }

--- a/source/NsDepCop.Core/Implementation/Config/AnalyzerConfigBuilder.cs
+++ b/source/NsDepCop.Core/Implementation/Config/AnalyzerConfigBuilder.cs
@@ -23,6 +23,7 @@ namespace Codartis.NsDepCop.Core.Implementation.Config
         public HashSet<NamespaceDependencyRule> DisallowRules { get; }
         public Dictionary<Namespace, TypeNameSet> VisibleTypesByNamespace { get; }
         public int? MaxIssueCount { get; private set; }
+        public int? MaxWarningErrorThreshold { get; private set; }
 
         public AnalyzerConfigBuilder()
         {
@@ -41,7 +42,8 @@ namespace Codartis.NsDepCop.Core.Implementation.Config
                 AllowRules,
                 DisallowRules,
                 VisibleTypesByNamespace,
-                MaxIssueCount ?? ConfigDefaults.MaxIssueCount
+                MaxIssueCount ?? ConfigDefaults.MaxIssueCount,
+                MaxWarningErrorThreshold
                 );
         }
 
@@ -148,7 +150,13 @@ namespace Codartis.NsDepCop.Core.Implementation.Config
                 MaxIssueCount = maxIssueCount;
             return this;
         }
+        public AnalyzerConfigBuilder SetMaxWarningErrorThreshold(int? maxWarningErrorThreshold)
+        {
+            if (maxWarningErrorThreshold.HasValue)
+                MaxWarningErrorThreshold = maxWarningErrorThreshold;
+            return this;
 
+        }
         public IEnumerable<string> ToStrings()
         {
             if (InheritanceDepth.HasValue) yield return $"InheritanceDepth={InheritanceDepth}";
@@ -161,6 +169,10 @@ namespace Codartis.NsDepCop.Core.Implementation.Config
             if (DisallowRules.Any()) foreach (var s in DisallowRules.ToStrings()) yield return s;
             if (VisibleTypesByNamespace.Any()) foreach (var s in VisibleTypesByNamespace.ToStrings()) yield return s;
             if (MaxIssueCount.HasValue) yield return $"MaxIssueCount={MaxIssueCount}";
+            if (MaxWarningErrorThreshold.HasValue) yield return $"MaxWarningErrorThreshold={MaxWarningErrorThreshold}";
+
         }
+
+
     }
 }

--- a/source/NsDepCop.Core/Implementation/Config/XmlConfigParser.cs
+++ b/source/NsDepCop.Core/Implementation/Config/XmlConfigParser.cs
@@ -18,6 +18,7 @@ namespace Codartis.NsDepCop.Core.Implementation.Config
         private const string IsEnabledAttributeName = "IsEnabled";
         private const string CodeIssueKindAttributeName = "CodeIssueKind";
         private const string MaxIssueCountAttributeName = "MaxIssueCount";
+        private const string MaxWarningErrorThresholdAttributeName = "MaxWarningErrorThreshold";
         private const string ImplicitParentDependencyAttributeName = "ChildCanDependOnParentImplicitly";
         private const string InfoImportanceAttributeName = "InfoImportance";
         private const string AllowedElementName = "Allowed";
@@ -51,6 +52,7 @@ namespace Codartis.NsDepCop.Core.Implementation.Config
             configBuilder.SetInfoImportance(ParseAttribute<Importance>(rootElement, InfoImportanceAttributeName, Enum.TryParse));
             configBuilder.SetChildCanDependOnParentImplicitly(ParseAttribute<bool>(rootElement, ImplicitParentDependencyAttributeName, bool.TryParse));
             configBuilder.SetMaxIssueCount(ParseAttribute<int>(rootElement, MaxIssueCountAttributeName, int.TryParse));
+            configBuilder.SetMaxWarningErrorThreshold(ParseAttribute<int>(rootElement, MaxWarningErrorThresholdAttributeName, int.TryParse));
         }
 
         private static void ParseChildElements(XElement rootElement, AnalyzerConfigBuilder configBuilder)

--- a/source/NsDepCop.Core/Interface/Analysis/IssueDefinitions.cs
+++ b/source/NsDepCop.Core/Interface/Analysis/IssueDefinitions.cs
@@ -33,11 +33,18 @@ namespace Codartis.NsDepCop.Core.Interface.Analysis
                 IssueKind.Info,
                 "Analysis is disabled in the nsdepcop config file.");
 
-        public static readonly IssueDescriptor<Exception> ConfigExceptionIssue = 
+        public static readonly IssueDescriptor<Exception> ConfigExceptionIssue =
             new IssueDescriptor<Exception>(
                 "NSDEPCOP05",
                 IssueKind.Error,
                 "Error loading NsDepCop config.",
+                i => $"{i?.Message}");
+
+        public static readonly IssueDescriptor<Exception> MaxWarningErrorThresholdExceededIssue =
+            new IssueDescriptor<Exception>(
+                "NSDEPCOP06",
+                IssueKind.Error,
+                "Too many warnings have been issued",
                 i => $"{i?.Message}");
     }
 }

--- a/source/NsDepCop.Core/Interface/Config/IAnalyzerConfig.cs
+++ b/source/NsDepCop.Core/Interface/Config/IAnalyzerConfig.cs
@@ -23,6 +23,13 @@ namespace Codartis.NsDepCop.Core.Interface.Config
         int MaxIssueCount { get; }
 
         /// <summary>
+        /// Gets the max warning error threshold.
+        /// </summary>
+        int? MaxWarningErrorThreshold { get; }
+
+
+
+        /// <summary>
         /// Gets the importance level of information messages. 
         /// Influences whether messages are emitted or suppressed by the host.
         /// </summary>

--- a/source/NsDepCop.MsBuildTask.Test/MsBuildLoggerGatewayTests.cs
+++ b/source/NsDepCop.MsBuildTask.Test/MsBuildLoggerGatewayTests.cs
@@ -71,6 +71,22 @@ namespace Codartis.NsDepCop.MsBuildTask.Test
             VerifyLogMessageEvent("MyParameter", MessageImportance.Normal);
         }
 
+        [Fact]
+        public void ExceedingMaxWarningErrorThresholdCausesIssueToBeLogged()
+        {
+
+            //Given a logger
+            var msBuildLoggerGateway = CreateLogger();
+            //And that logger has a maxWarningErrorThreshold
+            msBuildLoggerGateway.SetMaxWarningErrorThreshold(0);
+            //When there have been more warnings logged than the maxWarningErrorThreshold
+            var issue = new IssueDescriptor<string>("MyCode", IssueKind.Warning, "MyDescription", i => i);
+            msBuildLoggerGateway.LogIssue(issue, "MyParameter");
+            //Then an error should be logged
+            VerifyLogErrorEvent(IssueDefinitions.MaxWarningErrorThresholdExceededIssue.Id, "MaxWarningErrorThreshold has been exceeded");
+        }
+
+
         private MsBuildLoggerGateway CreateLogger() => new MsBuildLoggerGateway(_buildEngineMock.Object);
 
         private void VerifyLogMessageEvent(string message, MessageImportance messageImportance) =>

--- a/source/NsDepCop.MsBuildTask/ILogger.cs
+++ b/source/NsDepCop.MsBuildTask/ILogger.cs
@@ -43,5 +43,7 @@ namespace Codartis.NsDepCop.MsBuildTask
         /// </summary>
         /// <param name="message">A string message.</param>
         void LogTraceMessage(string message);
+
+        void SetMaxWarningErrorThreshold(int? maxWarningErrorThreshold);
     }
 }


### PR DESCRIPTION
Hi, I've implemented the `MaxWarnings` from #22 as `MaxWarningErrorThreshold` (not sure if that's a better name or not).

I couldn't think of a nicer way to get the MaxWarningErrorThreshold into the logger at the construction time of the logger (as the logger is used right from the start of the programs lifecycle), but what I've done (added a `.SetMaxWarningErrorThreshold()` method on the logger) should work.