### PR TITLE
fix #60: the type of a static method is detected

### DIFF
--- a/source/NsDepCop.SourceTest/Cs6Tests.cs
+++ b/source/NsDepCop.SourceTest/Cs6Tests.cs
@@ -292,5 +292,15 @@ namespace Codartis.NsDepCop.SourceTest
 
                 .Execute();
         }
+
+        [Fact]
+        public void Cs6_StaticImport()
+        {
+            SourceTestSpecification.Create()
+                .ExpectInvalidSegment(9, 13, 32)
+                .ExpectInvalidSegment(10, 13, 34) // because of the return value
+                .ExpectInvalidSegment(10, 13, 34) // because of the declaring type
+                .Execute();
+        }
     }
 }

--- a/source/NsDepCop.SourceTest/Cs6_StaticImport/Cs6_StaticImport.cs
+++ b/source/NsDepCop.SourceTest/Cs6_StaticImport/Cs6_StaticImport.cs
@@ -1,0 +1,22 @@
+﻿namespace B
+{
+    using static A.ClassA;
+
+    public class ClassB
+    {
+        public void CallA()
+        {
+            IsCalledReturnsVoid();    // #60 call dependency itself is ignored
+            IsCalledReturnsClassA();  // #60 produces warning based on return type (but not on the call itself)
+        }
+    }
+}
+
+namespace A
+{
+    public class ClassA
+    {
+        public static void IsCalledReturnsVoid() { _ = new ClassA();}
+        public static ClassA IsCalledReturnsClassA() { return new ClassA(); }
+    }
+}

--- a/source/NsDepCop.SourceTest/Cs6_StaticImport/config.nsdepcop
+++ b/source/NsDepCop.SourceTest/Cs6_StaticImport/config.nsdepcop
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<NsDepCopConfig>
+    <Allowed From="*" To="*" />
+    <Disallowed From="B.*" To="A.*" />
+</NsDepCopConfig>

--- a/source/NsDepCop.SourceTest/NsDepCop.SourceTest.csproj
+++ b/source/NsDepCop.SourceTest/NsDepCop.SourceTest.csproj
@@ -98,6 +98,9 @@
     <Compile Remove="Cs6_QualifiedName\Cs6_QualifiedName.cs">
 
     </Compile>
+    <Compile Remove="Cs6_StaticImport\Cs6_StaticImport.cs">
+
+    </Compile>
     <Compile Remove="Cs6_PointerType\Cs6_PointerType.cs">
 
     </Compile>
@@ -219,6 +222,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Cs6_QualifiedName\Cs6_QualifiedName.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Cs6_StaticImport\Cs6_StaticImport.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Cs6_PointerType\Cs6_PointerType.cs">
@@ -351,6 +357,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Cs6_QualifiedName\config.nsdepcop">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Cs6_StaticImport\config.nsdepcop">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Cs6_VarWithConstructedGenericType\config.nsdepcop">


### PR DESCRIPTION
... even if the method is called on a statically imported type

I tried to fix this bug. 
My solution differs from your proposal, but I think that it solves the problem with a small impact of code size and complexity as well as of the processing speed.
I do not expect unwanted side effects as it only adds dependencies when a static method is called without referencing the declaring class directly. So the set of additional dependencies is well defined and no duplicates are produced.

I negated the logic in the method `DetermineExtensionMethodDeclaringType` because I thought it is easier to understand than 
```cs
return methodSymbol == null || !(methodSymbol.IsExtensionMethod || (methodSymbol.IsStatic && node.Parent is not MemberAccessExpressionSyntax))
                ? null
                : methodSymbol.ContainingType;
```  
But I'm willing to change this if you have another opinion.