### PR TITLE
Enable Checking of Top Level Statement Files in NSDepCop

### DIFF
--- a/source/NsDepCop.Analyzer/ParserAdapter/Roslyn/SyntaxNodeAnalyzer.cs
+++ b/source/NsDepCop.Analyzer/ParserAdapter/Roslyn/SyntaxNodeAnalyzer.cs
@@ -197,9 +197,14 @@ namespace Codartis.NsDepCop.ParserAdapter.Roslyn
         private static ITypeSymbol DetermineEnclosingType(SyntaxNode node, SemanticModel semanticModel)
         {
             // Find the type declaration that contains the current syntax node.
-            var typeDeclarationSyntaxNode = node.Ancestors().FirstOrDefault(i => i.IsTypeDeclaration());
+            var typeDeclarationSyntaxNode = node.Ancestors().FirstOrDefault(i => i.IsTypeDeclaration() || i is CompilationUnitSyntax);
             if (typeDeclarationSyntaxNode == null)
                 return null;
+
+            if (typeDeclarationSyntaxNode is CompilationUnitSyntax)
+            {
+                return semanticModel.GetDeclaredSymbol(typeDeclarationSyntaxNode)?.ContainingType;
+            }
 
             // Determine the type of the type declaration that contains the current syntax node.
             return semanticModel.GetDeclaredSymbol(typeDeclarationSyntaxNode) as ITypeSymbol;

--- a/source/NsDepCop.SourceTest/AnalyzerFeatureTests.cs
+++ b/source/NsDepCop.SourceTest/AnalyzerFeatureTests.cs
@@ -96,5 +96,15 @@ namespace Codartis.NsDepCop.SourceTest
 
                 .Execute();
         }
+
+        [Fact]
+        public void AnalyzerFeature_WithTopLevelStatement()
+        {
+            SourceTestSpecification.Create()
+
+                .ExpectInvalidSegment(1, 8, 12)
+
+                .Execute(Microsoft.CodeAnalysis.OutputKind.ConsoleApplication);
+        }
     }
 }

--- a/source/NsDepCop.SourceTest/AnalyzerFeature_WithTopLevelStatement/AnalyzerFeature_WithTopLevelStatement.cs
+++ b/source/NsDepCop.SourceTest/AnalyzerFeature_WithTopLevelStatement/AnalyzerFeature_WithTopLevelStatement.cs
@@ -1,0 +1,1 @@
+﻿System.Type field3;

--- a/source/NsDepCop.SourceTest/AnalyzerFeature_WithTopLevelStatement/config.nsdepcop
+++ b/source/NsDepCop.SourceTest/AnalyzerFeature_WithTopLevelStatement/config.nsdepcop
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<NsDepCopConfig>
+</NsDepCopConfig>

--- a/source/NsDepCop.SourceTest/NsDepCop.SourceTest.csproj
+++ b/source/NsDepCop.SourceTest/NsDepCop.SourceTest.csproj
@@ -47,6 +47,7 @@
     <Compile Remove="AnalyzerFeature_VisibleMembersOfNamespace\AnalyzerFeature_VisibleMembersOfNamespace.cs">
 
     </Compile>
+    <Compile Remove="AnalyzerFeature_WithTopLevelStatement\AnalyzerFeature_WithTopLevelStatement.cs" />
     <Compile Remove="Cs7_IsExpressionWithPattern\Cs7_IsExpressionWithPattern.cs">
 
     </Compile>
@@ -174,6 +175,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="AnalyzerFeature_VisibleMembersOfNamespace\AnalyzerFeature_VisibleMembersOfNamespace.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="AnalyzerFeature_WithTopLevelStatement\AnalyzerFeature_WithTopLevelStatement.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Cs7_IsExpressionWithPattern\Cs7_IsExpressionWithPattern.cs">
@@ -315,6 +319,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="AnalyzerFeature_VisibleMembersOfNamespace\config.nsdepcop">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="AnalyzerFeature_WithTopLevelStatement\config.nsdepcop">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Cs6_AliasQualifiedName\config.nsdepcop">

--- a/source/NsDepCop.SourceTest/SourceTestSpecification.cs
+++ b/source/NsDepCop.SourceTest/SourceTestSpecification.cs
@@ -45,24 +45,24 @@ namespace Codartis.NsDepCop.SourceTest
             return this;
         }
 
-        public void Execute()
+        public void Execute(OutputKind? outputKind = null)
         {
             var sourceFilePaths = new[] {_name}.Select(GetTestFileFullPath).ToList();
             var referencedAssemblyPaths = GetReferencedAssemblyPaths().ToList();
 
-            ValidateCompilation(sourceFilePaths, referencedAssemblyPaths);
+            ValidateCompilation(sourceFilePaths, referencedAssemblyPaths, outputKind ?? OutputKind.DynamicallyLinkedLibrary);
             AssertIllegalDependencies(sourceFilePaths, referencedAssemblyPaths);
         }
 
         private static void DebugMessageHandler(string message) => Debug.WriteLine(message);
 
-        private void ValidateCompilation(IEnumerable<string> sourceFiles, IEnumerable<string> referencedAssemblies)
+        private void ValidateCompilation(IEnumerable<string> sourceFiles, IEnumerable<string> referencedAssemblies, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary)
         {
             var compilation = CSharpCompilation.Create(
                 "NsDepCopProject",
                 sourceFiles.Select(i => CSharpSyntaxTree.ParseText(LoadFile(i), CSharpParseOptions)),
                 referencedAssemblies.Select(i => MetadataReference.CreateFromFile(i)),
-                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+                new CSharpCompilationOptions(outputKind, allowUnsafe: true));
 
             var errors = compilation.GetDiagnostics().Where(i => i.Severity == DiagnosticSeverity.Error).ToList();
             errors.Should().HaveCount(0);


### PR DESCRIPTION
Hi,

the reason i opened this pull request is the following:
I tried to use NSDepCop in one of our Source-Repositories and noticed that no violations were triggered in our Program.cs.

So i forked the code and hopefully fixed this issue.
I also added a simple Testcase and extended the TestInfrastructure so that i could use the OutputKind ConsoleApplication.

Regards,
Johannes