### PR TITLE
Regex-Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # NsDepCop Change Log
 
+## v2.6.0
+(02/2025)
+
+- [x] New: Regex patterns for assemblies and namespaces.
+
 ## v2.5.0
 (01/2025)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 image: Visual Studio 2022
 
 environment:
-  shortversion: '2.5.0'
-  informationalversion: '2.5.0'
+  shortversion: '2.6.0'
+  informationalversion: '2.6.0'
 
 version: '$(shortversion).{build}'
 

--- a/source/NsDepCop.Analyzer/Config/DomainSpecificationParser.cs
+++ b/source/NsDepCop.Analyzer/Config/DomainSpecificationParser.cs
@@ -15,6 +15,8 @@ namespace Codartis.NsDepCop.Config
         /// </remarks>
         public static DomainSpecification Parse(string domainSpecificationAsString)
         {
+            if (domainSpecificationAsString.StartsWith(RegexDomain.Delimiter) && domainSpecificationAsString.EndsWith(RegexDomain.Delimiter))
+                return new RegexDomain(domainSpecificationAsString);
             if (domainSpecificationAsString.Contains(WildcardDomain.SingleDomainMarker) || domainSpecificationAsString.Contains(WildcardDomain.AnyDomainMarker))
                 return new WildcardDomain(domainSpecificationAsString);
             return new Domain(domainSpecificationAsString);

--- a/source/NsDepCop.Analyzer/Config/RegexCompilationMode.cs
+++ b/source/NsDepCop.Analyzer/Config/RegexCompilationMode.cs
@@ -1,0 +1,7 @@
+namespace Codartis.NsDepCop.Config;
+
+public enum RegexCompilationMode
+{
+    Compiled,
+    Interpreted
+}

--- a/source/NsDepCop.Analyzer/Config/RegexDomain.cs
+++ b/source/NsDepCop.Analyzer/Config/RegexDomain.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Codartis.NsDepCop.Config;
 
+[Serializable]
 public sealed class RegexDomain : DomainSpecification
 {
     public const string Delimiter = "/";

--- a/source/NsDepCop.Analyzer/Config/RegexDomain.cs
+++ b/source/NsDepCop.Analyzer/Config/RegexDomain.cs
@@ -23,6 +23,12 @@ public sealed class RegexDomain : DomainSpecification
 
     private static bool IsValid(string domainAsString)
     {
+        if (!domainAsString.StartsWith(Delimiter, StringComparison.Ordinal)
+            || !domainAsString.EndsWith(Delimiter, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
         var normalizedDomainAsString = Normalize(domainAsString);
         if (string.IsNullOrWhiteSpace(normalizedDomainAsString))
             return false;

--- a/source/NsDepCop.Analyzer/Config/RegexDomain.cs
+++ b/source/NsDepCop.Analyzer/Config/RegexDomain.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Codartis.NsDepCop.Config;
+
+public sealed class RegexDomain : DomainSpecification
+{
+    public const string Delimiter = "/";
+
+    public RegexDomain(string value, bool validate = true)
+        : base(value, validate, IsValid)
+    {
+    }
+
+    public override int GetMatchRelevance(Domain domain)
+    {
+        return Regex.IsMatch(domain.ToString(), Normalize(this.Value))
+            ? int.MaxValue
+            : 0;
+    }
+
+    private static bool IsValid(string domainAsString)
+    {
+        var normalizedDomainAsString = Normalize(domainAsString);
+        if (string.IsNullOrWhiteSpace(normalizedDomainAsString))
+            return false;
+
+        try
+        {
+            _ = new Regex(normalizedDomainAsString);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private static string Normalize(string domainAsString)
+    {
+        return domainAsString.Trim(Delimiter.ToCharArray());
+    }
+}

--- a/source/NsDepCop.Analyzer/Config/RegexDomain.cs
+++ b/source/NsDepCop.Analyzer/Config/RegexDomain.cs
@@ -3,6 +3,15 @@ using System.Text.RegularExpressions;
 
 namespace Codartis.NsDepCop.Config;
 
+/// <summary>
+/// Represents a domain specification with a regular expression pattern.
+/// The given pattern must follow the dotnet regex specification found at:
+/// https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-language-quick-reference
+/// </summary>
+/// <remarks>
+/// This class provides functionality to define a domain using a regular expression
+/// and supports validation and matching of other domains against the specified pattern.
+/// </remarks>
 [Serializable]
 public sealed class RegexDomain : DomainSpecification
 {

--- a/source/NsDepCop.Analyzer/Config/RegexDomain.cs
+++ b/source/NsDepCop.Analyzer/Config/RegexDomain.cs
@@ -13,11 +13,13 @@ public sealed class RegexDomain : DomainSpecification
     }
 
     public override int GetMatchRelevance(Domain domain)
-    {
-        return Regex.IsMatch(domain.ToString(), Normalize(this.Value))
-            ? int.MaxValue
+        => Regex.IsMatch(
+            domain.ToString(),
+            Normalize(this.Value),
+            RegexOptions.Compiled | RegexOptions.Singleline,
+            TimeSpan.FromMilliseconds(100))
+            ? 1
             : 0;
-    }
 
     private static bool IsValid(string domainAsString)
     {
@@ -37,7 +39,5 @@ public sealed class RegexDomain : DomainSpecification
     }
 
     private static string Normalize(string domainAsString)
-    {
-        return domainAsString.Trim(Delimiter.ToCharArray());
-    }
+        => domainAsString.Trim(Delimiter.ToCharArray());
 }

--- a/source/NsDepCop.Analyzer/Config/RegexUsageMode.cs
+++ b/source/NsDepCop.Analyzer/Config/RegexUsageMode.cs
@@ -1,0 +1,7 @@
+namespace Codartis.NsDepCop.Config;
+
+public enum RegexUsageMode
+{
+    Static,
+    Instance
+}

--- a/source/NsDepCop.Benchmarks/NsDepCop.Benchmarks.RuleTypesBenchmarks-report-github.md
+++ b/source/NsDepCop.Benchmarks/NsDepCop.Benchmarks.RuleTypesBenchmarks-report-github.md
@@ -1,0 +1,20 @@
+```
+
+BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.5608/22H2/2022Update)
+Intel Core i7-10850H CPU 2.70GHz, 1 CPU, 12 logical and 6 physical cores
+.NET SDK 9.0.201
+  [Host]     : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2
+
+
+```
+| Method             | Iterations | regexCompilationMode | useStaticRegexCache | Mean           | Error        | StdDev      | Gen0      | Gen1      | Allocated |
+|------------------- |----------- |--------------------- |-------------------- |---------------:|-------------:|------------:|----------:|----------:|----------:|
+| SimpleRule         | 1000       | ?                    | ?                   |       274.7 μs |      2.82 μs |     2.50 μs |  187.5000 |    0.4883 |   1.12 MB |
+| WildcardRule       | 1000       | ?                    | ?                   |       493.7 μs |      3.13 μs |     2.93 μs |  259.7656 |    0.9766 |   1.56 MB |
+| RegexRule_Instance | 1000       | Interpreted          | ?                   |       507.8 μs |      4.79 μs |     4.24 μs |  187.5000 |         - |   1.13 MB |
+| RegexRule_Static   | 1000       | Compiled             | True                |       536.1 μs |     10.63 μs |     9.94 μs |  221.6797 |         - |   1.33 MB |
+| RegexRule_Static   | 1000       | Interpreted          | True                |       642.8 μs |      6.56 μs |     6.13 μs |  221.6797 |         - |   1.33 MB |
+| RegexRule_Instance | 1000       | Compiled             | ?                   |     1,065.3 μs |      3.66 μs |     3.24 μs |  189.4531 |   19.5313 |   1.13 MB |
+| RegexRule_Static   | 1000       | Interpreted          | False               |     2,859.5 μs |     28.90 μs |    24.13 μs | 1312.5000 |         - |   7.94 MB |
+| RegexRule_Static   | 1000       | Compiled             | False               | 1,948,017.4 μs | 10,476.50 μs | 8,748.35 μs | 4000.0000 | 3000.0000 |  29.51 MB |

--- a/source/NsDepCop.Benchmarks/NsDepCop.Benchmarks.csproj
+++ b/source/NsDepCop.Benchmarks/NsDepCop.Benchmarks.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Include="..\Include\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+		<Compile Include="..\Include\VersionInfo.cs" Link="Properties\VersionInfo.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\NsDepCop.Test\NsDepCop.Test.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/source/NsDepCop.Benchmarks/Program.cs
+++ b/source/NsDepCop.Benchmarks/Program.cs
@@ -1,0 +1,11 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace NsDepCop.Benchmarks;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        BenchmarkRunner.Run<RuleTypesBenchmarks>();
+    }
+}

--- a/source/NsDepCop.Benchmarks/RuleTypesBenchmarks.cs
+++ b/source/NsDepCop.Benchmarks/RuleTypesBenchmarks.cs
@@ -1,0 +1,83 @@
+﻿using System.Text.RegularExpressions;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using Codartis.NsDepCop.Analysis;
+using Codartis.NsDepCop.Analysis.Implementation;
+using Codartis.NsDepCop.Config;
+using Codartis.NsDepCop.Test.Implementation.Analysis;
+using FluentAssertions;
+
+namespace NsDepCop.Benchmarks;
+
+[MemoryDiagnoser]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class RuleTypesBenchmarks
+{
+    [Params(1000)]
+    public int Iterations { get; set; }
+
+    [Benchmark]
+    public void SimpleRule()
+    {
+        var config = new DependencyRulesBuilder().AddAllowed(new Domain("A.B.C"), new Domain("D.E.F"));
+        BenchmarkCore(config, Iterations);
+    }
+
+    [Benchmark]
+    public void WildcardRule()
+    {
+        var config = new DependencyRulesBuilder().AddAllowed(new WildcardDomain("A.?.?"), new WildcardDomain("D.*"));
+        BenchmarkCore(config, Iterations);
+    }
+
+    /// <summary>
+    /// Benchmark using a Regex object instance, with or without RegexOptions.Compiled.
+    /// </summary>
+    [Benchmark]
+    [Arguments(RegexCompilationMode.Compiled)]
+    [Arguments(RegexCompilationMode.Interpreted)]
+    public void RegexRule_Instance(RegexCompilationMode regexCompilationMode)
+    {
+        var regexDomain = new RegexDomain("/[A-Z.]*/", validate: true, RegexUsageMode.Instance, regexCompilationMode);
+        var config = new DependencyRulesBuilder().AddAllowed(regexDomain, regexDomain);
+        BenchmarkCore(config, Iterations);
+    }
+
+    /// <summary>
+    /// Benchmark using the static Regex.IsMatch method, with or without RegexOptions.Compiled,
+    /// and with or without using the built-in cache for static Regex.IsMatch calls.
+    /// The reason behind measuring performance also with the static Regex cache turned off,
+    /// is that in real-world usage there probably will be more than 15 different patterns,
+    /// so the cache won't be effective anyway.
+    /// </summary>
+    /// <remarks>
+    /// See: https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-regex
+    /// By default, the last 15 most recently used static regular expression patterns are cached.
+    /// For applications that require a larger number of cached static regular expressions,
+    /// the size of the cache can be adjusted by setting the Regex.CacheSize property.
+    /// </remarks>
+    [Benchmark]
+    [Arguments(RegexCompilationMode.Compiled, true)]
+    [Arguments(RegexCompilationMode.Compiled, false)]
+    [Arguments(RegexCompilationMode.Interpreted, true)]
+    [Arguments(RegexCompilationMode.Interpreted, false)]
+    public void RegexRule_Static(RegexCompilationMode regexCompilationMode, bool useStaticRegexCache)
+    {
+        Regex.CacheSize = useStaticRegexCache ? 15 : 0;
+
+        var regexDomain = new RegexDomain("/[A-Z.]*/", validate: true, RegexUsageMode.Static, regexCompilationMode);
+        var config = new DependencyRulesBuilder().AddAllowed(regexDomain, regexDomain);
+        BenchmarkCore(config, Iterations);
+    }
+
+    private static void BenchmarkCore(IDependencyRules config, int iterations)
+    {
+        var typeDependencyValidator = new TypeDependencyValidator(config);
+
+        for (var i = 0; i < iterations; i++)
+        {
+            var dependencyStatus = typeDependencyValidator.IsAllowedDependency(new TypeDependency("A.B.C", "T", "D.E.F", "T", default));
+            dependencyStatus.IsAllowed.Should().BeTrue();
+        }
+    }
+}

--- a/source/NsDepCop.Benchmarks/readme.txt
+++ b/source/NsDepCop.Benchmarks/readme.txt
@@ -1,0 +1,6 @@
+How to run the benchmarks?
+
+1. Build the solution with Release config.
+2. Run the NsDepCop.Benchmarks project.
+3. Compare the new results (in the NsDepCop.Benchmarks\bin\Release\net8.0\BenchmarkDotNet.Artifacts\results folder)
+   with the saved result (in the NsDepCop.Benchmarks folder).

--- a/source/NsDepCop.NuGet/NsDepCop.NuGet.csproj
+++ b/source/NsDepCop.NuGet/NsDepCop.NuGet.csproj
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <PackageId>NsDepCop</PackageId>
-    <PackageVersion>2.5.0-local</PackageVersion>
+    <PackageVersion>2.6.0-local</PackageVersion>
     <Title>NsDepCop - Namespace and Assembly Dependency Checker Tool for C#</Title>
     <Description>NsDepCop is a static code analysis tool that enforces namespace and assembly dependency rules in C# projects.</Description>
     <PackageTags>static code analysis analyzer tool C# csharp namespace type assembly dependency dependencies</PackageTags>

--- a/source/NsDepCop.SourceTest/FileBasedTestsBase.cs
+++ b/source/NsDepCop.SourceTest/FileBasedTestsBase.cs
@@ -28,14 +28,6 @@ namespace Codartis.NsDepCop.SourceTest
             return Path.Combine(GetExecutingAssemblyDirectory(), filename);
         }
 
-        protected string GetFilePathInTestClassFolder(string filename)
-        {
-            var namespacePrefix = $"Codartis.{this.GetType().Assembly.GetName().Name}";
-            var namespacePostfix = GetType().FullName.Remove(0, namespacePrefix.Length + 1).Replace('.', '\\');
-
-            return GetBinFilePath(Path.Combine(namespacePostfix, filename));
-        }
-
         protected string LoadFile(string fullPath)
         {
             using (var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/source/NsDepCop.SourceTest/SourceTestSpecification.cs
+++ b/source/NsDepCop.SourceTest/SourceTestSpecification.cs
@@ -101,7 +101,8 @@ namespace Codartis.NsDepCop.SourceTest
 
         private static string GetTestFileFullPath(string testName)
         {
-            return Path.Combine(GetBinFilePath($@"{testName}\{testName}.cs"));
+            var relativeTestFilePath = Path.Combine(testName, testName + ".cs");
+            return Path.Combine(GetBinFilePath(relativeTestFilePath));
         }
 
         private static IEnumerable<string> GetReferencedAssemblyPaths()

--- a/source/NsDepCop.Test/FileBasedTestsBase.cs
+++ b/source/NsDepCop.Test/FileBasedTestsBase.cs
@@ -31,7 +31,7 @@ namespace Codartis.NsDepCop.Test
         protected string GetFilePathInTestClassFolder(string filename)
         {
             var namespacePrefix = $"Codartis.{this.GetType().Assembly.GetName().Name}";
-            var namespacePostfix = GetType().FullName.Remove(0, namespacePrefix.Length + 1).Replace('.', '\\');
+            var namespacePostfix = GetType().FullName.Remove(0, namespacePrefix.Length + 1).Replace('.', '/');
 
             return GetBinFilePath(Path.Combine(namespacePostfix, filename));
         }

--- a/source/NsDepCop.Test/Implementation/Analysis/DependencyRulesBuilder.cs
+++ b/source/NsDepCop.Test/Implementation/Analysis/DependencyRulesBuilder.cs
@@ -6,7 +6,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Analysis
     /// <summary>
     /// Helper class for unit testing. Enables rule config building.
     /// </summary>
-    internal class DependencyRulesBuilder : IDependencyRules
+    public class DependencyRulesBuilder : IDependencyRules
     {
         private readonly Dictionary<DependencyRule, TypeNameSet> _allowedDependencies;
         private readonly HashSet<DependencyRule> _disallowedDependencies;
@@ -38,6 +38,12 @@ namespace Codartis.NsDepCop.Test.Implementation.Analysis
         public DependencyRulesBuilder SetChildCanDependOnParentImplicitly(bool value)
         {
             ChildCanDependOnParentImplicitly = value;
+            return this;
+        }
+
+        public DependencyRulesBuilder AddAllowed(DomainSpecification from, DomainSpecification to, params string[] typeNames)
+        {
+            _allowedDependencies.Add(new DependencyRule(from, to), new TypeNameSet(typeNames));
             return this;
         }
 

--- a/source/NsDepCop.Test/Implementation/Analysis/TypeDependencyValidatorTests.cs
+++ b/source/NsDepCop.Test/Implementation/Analysis/TypeDependencyValidatorTests.cs
@@ -132,7 +132,19 @@ namespace Codartis.NsDepCop.Test.Implementation.Analysis
             dependencyValidator.IsAllowedDependency("A.B.C.S", "C1", "U.V.T", "C2").Should().BeTrue();
             dependencyValidator.IsAllowedDependency("A.B.C.D.S", "C1", "U.V.T", "C2").Should().BeFalse();
         }
-        
+
+        [Fact]
+        public void AllowRule_WildcardRuleIsStrongerThanRegexRule()
+        {
+            var ruleConfig = new DependencyRulesBuilder()
+                .AddAllowed("A.*.S", "U.V.T", "C3")
+                .AddAllowed("/A...S/", "U.V.T");
+
+            var dependencyValidator = CreateTypeDependencyValidator(ruleConfig);
+            dependencyValidator.IsAllowedDependency("A.B.S", "C1", "U.V.T", "C3").Should().BeTrue();
+            dependencyValidator.IsAllowedDependency("A.B.S", "C1", "U.V.T", "C2").Should().BeFalse();
+        }
+
         [Fact]
         public void DisallowRule_LessSpecificRuleWithWildcardsIsStronger()
         {

--- a/source/NsDepCop.Test/Implementation/Config/MultiLevelXmlFileConfigProviderTests.cs
+++ b/source/NsDepCop.Test/Implementation/Config/MultiLevelXmlFileConfigProviderTests.cs
@@ -13,7 +13,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void Rules_Merged()
         {
-            var folder = GetFilePathInTestClassFolder(@"Rules_Merged\Level2\Level1");
+            var folder = GetFilePathInTestClassFolder(@"Rules_Merged/Level2/Level1");
             var configProvider = CreateConfigProvider(folder);
 
             configProvider.ConfigState.Should().Be(AnalyzerConfigState.Enabled);
@@ -28,7 +28,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void Attributes_LowerLevelWins()
         {
-            var folder = GetFilePathInTestClassFolder(@"Attributes_LowerLevelWins\Level2\Level1");
+            var folder = GetFilePathInTestClassFolder("Attributes_LowerLevelWins/Level2/Level1");
             var configProvider = CreateConfigProvider(folder);
             configProvider.Config.MaxIssueCount.Should().Be(2);
         }
@@ -36,7 +36,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void Attributes_MissingDoesNotOverwrite()
         {
-            var folder = GetFilePathInTestClassFolder(@"Attributes_MissingDoesNotOverwrite\Level2\Level1");
+            var folder = GetFilePathInTestClassFolder("Attributes_MissingDoesNotOverwrite/Level2/Level1");
             var configProvider = CreateConfigProvider(folder);
             configProvider.Config.MaxIssueCount.Should().Be(1);
         }
@@ -44,25 +44,25 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void ExcludedFiles_AllCorrectlyRooted()
         {
-            var folder = GetFilePathInTestClassFolder(@"ExcludedFiles_AllCorrectlyRooted\Level2\Level1");
+            var folder = GetFilePathInTestClassFolder("ExcludedFiles_AllCorrectlyRooted/Level2/Level1");
 
             var expectedExcludedFiles = new[]
             {
-                GetFilePathInTestClassFolder(@"ExcludedFiles_AllCorrectlyRooted\Level2\Level1\ExcludedFile1.cs"),
-                GetFilePathInTestClassFolder(@"ExcludedFiles_AllCorrectlyRooted\Level2\Level1\Excluded File 2.cs"),
-                GetFilePathInTestClassFolder(@"ExcludedFiles_AllCorrectlyRooted\Level2\ExcludedFile3.cs"),
-                GetFilePathInTestClassFolder(@"ExcludedFiles_AllCorrectlyRooted\Level2\Excluded File 4.cs"),
+                GetFilePathInTestClassFolder("ExcludedFiles_AllCorrectlyRooted/Level2/Level1/ExcludedFile1.cs"),
+                GetFilePathInTestClassFolder("ExcludedFiles_AllCorrectlyRooted/Level2/Level1/Excluded File 2.cs"),
+                GetFilePathInTestClassFolder("ExcludedFiles_AllCorrectlyRooted/Level2/ExcludedFile3.cs"),
+                GetFilePathInTestClassFolder("ExcludedFiles_AllCorrectlyRooted/Level2/Excluded File 4.cs"),
             };
 
             var configProvider = CreateConfigProvider(folder);
-            configProvider.Config.SourcePathExclusionPatterns.Should().BeEquivalentTo(expectedExcludedFiles);
+            configProvider.Config.SourcePathExclusionPatterns.Select(Path.GetFullPath).Should().BeEquivalentTo(expectedExcludedFiles.Select(Path.GetFullPath));
             configProvider.Config.SourcePathExclusionPatterns.All(File.Exists).Should().BeTrue();
         }
 
         [Fact]
         public void Properties_ConfigNotFound()
         {
-            var path = GetFilePathInTestClassFolder(@"NoConfig\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("NoConfig/Level2/Level1");
             var configProvider = CreateConfigProvider(path);
             configProvider.ConfigState.Should().Be(AnalyzerConfigState.NoConfig);
             configProvider.ConfigException.Should().BeNull();
@@ -72,7 +72,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void Properties_ConfigError()
         {
-            var path = GetFilePathInTestClassFolder(@"ConfigError\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("ConfigError/Level2/Level1");
             var configProvider = CreateConfigProvider(path);
             configProvider.ConfigState.Should().Be(AnalyzerConfigState.ConfigError);
             configProvider.ConfigException.Should().NotBeNull();
@@ -82,7 +82,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void Properties_ConfigEnabled()
         {
-            var path = GetFilePathInTestClassFolder(@"ConfigEnabled\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("ConfigEnabled/Level2/Level1");
             var configProvider = CreateConfigProvider(path);
             configProvider.ConfigState.Should().Be(AnalyzerConfigState.Enabled);
             configProvider.ConfigException.Should().BeNull();
@@ -92,7 +92,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void Properties_ConfigDisabledAtProjectLevel_EffectiveDisabled()
         {
-            var path = GetFilePathInTestClassFolder(@"ConfigDisabledAtProjectLevel\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("ConfigDisabledAtProjectLevel/Level2/Level1");
             var configProvider = CreateConfigProvider(path);
             configProvider.ConfigState.Should().Be(AnalyzerConfigState.Disabled);
             configProvider.ConfigException.Should().BeNull();
@@ -102,7 +102,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void Properties_ConfigDisabledAtHigherLevelAndUndefinedAtProjectLevel_EffectiveDisabled()
         {
-            var path = GetFilePathInTestClassFolder(@"ConfigDisabledAtHigherLevelAndUndefinedAtProjectLevel\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("ConfigDisabledAtHigherLevelAndUndefinedAtProjectLevel/Level2/Level1");
             var configProvider = CreateConfigProvider(path);
             configProvider.ConfigState.Should().Be(AnalyzerConfigState.Disabled);
             configProvider.ConfigException.Should().BeNull();
@@ -112,7 +112,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void Properties_ConfigDisabledAtHigherLevelButEnabledAtProjectLevel_DisabledConfigNotCombinedToEffective()
         {
-            var path = GetFilePathInTestClassFolder(@"ConfigDisabledAtHigherLevelButEnabledAtProjectLevel\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("ConfigDisabledAtHigherLevelButEnabledAtProjectLevel/Level2/Level1");
             var configProvider = CreateConfigProvider(path);
             configProvider.ConfigState.Should().Be(AnalyzerConfigState.Enabled);
             configProvider.ConfigException.Should().BeNull();
@@ -122,7 +122,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void RefreshConfig_Unchanged()
         {
-            var path = GetFilePathInTestClassFolder(@"ConfigEnabled\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("ConfigEnabled/Level2/Level1");
 
             var configProvider = CreateConfigProvider(path);
             configProvider.ConfigState.Should().Be(AnalyzerConfigState.Enabled);
@@ -136,8 +136,8 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void RefreshConfig_EnabledToEnabledButChanged()
         {
-            var path = GetFilePathInTestClassFolder(@"RefreshConfig_EnabledToEnabledButChanged\Level2\Level1");
-            var path2 = GetFilePathInTestClassFolder(@"RefreshConfig_EnabledToEnabledButChanged");
+            var path = GetFilePathInTestClassFolder("RefreshConfig_EnabledToEnabledButChanged/Level2/Level1");
+            var path2 = GetFilePathInTestClassFolder("RefreshConfig_EnabledToEnabledButChanged");
 
             SetAttribute(GetConfigFilePath(path), "AutoLowerMaxIssueCount", "true");
             SetAttribute(GetConfigFilePath(path2), "MaxIssueCount", "1");
@@ -158,7 +158,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void RefreshConfig_EnabledToDisabled()
         {
-            var path = GetFilePathInTestClassFolder(@"RefreshConfig_EnabledToDisabled\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("RefreshConfig_EnabledToDisabled/Level2/Level1");
 
             SetAttribute(GetConfigFilePath(path), "IsEnabled", "true");
 
@@ -175,7 +175,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void RefreshConfig_EnabledToConfigError()
         {
-            var path = GetFilePathInTestClassFolder(@"RefreshConfig_EnabledToConfigError\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("RefreshConfig_EnabledToConfigError/Level2/Level1");
 
             SetAttribute(GetConfigFilePath(path), "IsEnabled", "true");
 
@@ -192,7 +192,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void RefreshConfig_NoConfigToEnabled()
         {
-            var path = GetFilePathInTestClassFolder(@"RefreshConfig_NoConfigToEnabled\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("RefreshConfig_NoConfigToEnabled/Level2/Level1");
 
             Delete(GetConfigFilePath(path));
 
@@ -208,7 +208,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void RefreshConfig_EnabledToNoConfig()
         {
-            var path = GetFilePathInTestClassFolder(@"RefreshConfig_EnabledToNoConfig\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("RefreshConfig_EnabledToNoConfig/Level2/Level1");
 
             Delete(path);
             CreateConfigFile(GetConfigFilePath(path), "true", 2);
@@ -225,7 +225,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void RefreshConfig_InheritanceDepthChangedFrom0To2()
         {
-            var path = GetFilePathInTestClassFolder(@"RefreshConfig_InheritanceDepthChanged\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("RefreshConfig_InheritanceDepthChanged/Level2/Level1");
 
             SetAttribute(GetConfigFilePath(path), "InheritanceDepth", "0");
 
@@ -244,7 +244,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void RefreshConfig_InheritanceDepthChangedFrom2To0()
         {
-            var path = GetFilePathInTestClassFolder(@"RefreshConfig_InheritanceDepthChanged\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("RefreshConfig_InheritanceDepthChanged/Level2/Level1");
 
             SetAttribute(GetConfigFilePath(path), "InheritanceDepth", "2");
 
@@ -263,7 +263,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         [Fact]
         public void UpdateMaxIssueCount_Level1ContainsNoMaxIssueCount_SetToNewValue()
         {
-            var path = GetFilePathInTestClassFolder(@"UpdateMaxIssueCount_Level1ContainsNoMaxIssueCount\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("UpdateMaxIssueCount_Level1ContainsNoMaxIssueCount/Level2/Level1");
 
             RemoveAttribute(GetConfigFilePath(path), "MaxIssueCount");
 
@@ -274,14 +274,14 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
             configProvider.UpdateMaxIssueCount(142);
             configProvider.Config.MaxIssueCount.Should().Be(142);
 
-            GetAttribute(GetConfigFilePath(path.Replace(@"\Level1", "")), "MaxIssueCount").Should().Be(42.ToString());
+            GetAttribute(GetConfigFilePath(path.Replace("/Level1", "")), "MaxIssueCount").Should().Be(42.ToString());
             GetAttribute(GetConfigFilePath(path), "MaxIssueCount").Should().Be(142.ToString());
         }
 
         [Fact]
         public void UpdateMaxIssueCount_Level1ContainsMaxIssueCount_SetToNewValue()
         {
-            var path = GetFilePathInTestClassFolder(@"UpdateMaxIssueCount_Level1ContainsMaxIssueCount\Level2\Level1");
+            var path = GetFilePathInTestClassFolder("UpdateMaxIssueCount_Level1ContainsMaxIssueCount/Level2/Level1");
 
             SetAttribute(GetConfigFilePath(path), "MaxIssueCount", 42.ToString());
 
@@ -292,7 +292,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
             configProvider.UpdateMaxIssueCount(142);
             configProvider.Config.MaxIssueCount.Should().Be(142);
 
-            GetAttribute(GetConfigFilePath(path.Replace(@"\Level1", "")), "MaxIssueCount").Should().BeNull();
+            GetAttribute(GetConfigFilePath(path.Replace("/Level1", "")), "MaxIssueCount").Should().BeNull();
             GetAttribute(GetConfigFilePath(path), "MaxIssueCount").Should().Be(142.ToString());
         }
 

--- a/source/NsDepCop.Test/Implementation/Config/XmlConfigParserTests.cs
+++ b/source/NsDepCop.Test/Implementation/Config/XmlConfigParserTests.cs
@@ -33,7 +33,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
             configBuilder.MaxIssueCount.Should().Be(42);
             configBuilder.ChildCanDependOnParentImplicitly.Should().BeTrue();
             configBuilder.AutoLowerMaxIssueCount.Should().BeTrue();
-            configBuilder.SourcePathExclusionPatterns.Should().BeEquivalentTo(@"**/*.g.cs", @"TestData\**\*.cs");
+            configBuilder.SourcePathExclusionPatterns.Should().BeEquivalentTo("**/*.g.cs", @"TestData\**\*.cs");
             configBuilder.CheckAssemblyDependencies.Should().BeTrue();
         }
 

--- a/source/NsDepCop.Test/Implementation/Config/XmlFileConfigProviderTests.cs
+++ b/source/NsDepCop.Test/Implementation/Config/XmlFileConfigProviderTests.cs
@@ -36,7 +36,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         {
             var path = GetFilePathInTestClassFolder("ExcludedFiles.nsdepcop");
             var configProvider = CreateConfigProvider(path);
-            
+
             var expectedExcludedFiles = new[]
             {
                 GetFilePathInTestClassFolder("ExcludedFile1.cs"),
@@ -44,7 +44,7 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
             };
 
             var exclusionPatterns = configProvider.Config.SourcePathExclusionPatterns;
-            exclusionPatterns.Should().BeEquivalentTo(expectedExcludedFiles);
+            exclusionPatterns.Select(Path.GetFullPath).Should().BeEquivalentTo(expectedExcludedFiles.Select(Path.GetFullPath));
             exclusionPatterns.All(File.Exists).Should().BeTrue();
         }
 

--- a/source/NsDepCop.Test/Interface/Config/DomainSpecificationParserTests.cs
+++ b/source/NsDepCop.Test/Interface/Config/DomainSpecificationParserTests.cs
@@ -30,10 +30,19 @@ namespace Codartis.NsDepCop.Test.Interface.Config
         }
 
         [Theory]
+        [InlineData("/Unit\\.Test/")]
+        [InlineData("/^Unit\\.Test$/")]
+        public void Parse_RegexDomainSpecification(string regexDomainString)
+        {
+            DomainSpecificationParser.Parse(regexDomainString).Should().Be(new RegexDomain(regexDomainString));
+        }
+
+        [Theory]
         [InlineData("..")]
         [InlineData(".A")]
         [InlineData("A.")]
         [InlineData("*.*")]
+        [InlineData("/foo{2,1}/")]
         public void Parse_Invalid(string invalidString)
         {
             Assert.Throws<FormatException>(() => DomainSpecificationParser.Parse(invalidString));

--- a/source/NsDepCop.Test/Interface/Config/DomainSpecificationTests.cs
+++ b/source/NsDepCop.Test/Interface/Config/DomainSpecificationTests.cs
@@ -1,4 +1,5 @@
-﻿using Codartis.NsDepCop.Config;
+﻿using System.Linq;
+using Codartis.NsDepCop.Config;
 using FluentAssertions;
 using Xunit;
 
@@ -6,52 +7,57 @@ namespace Codartis.NsDepCop.Test.Interface.Config
 {
     public class DomainSpecificationTests
     {
-        [Fact]
-        public void GetMatchRelevance()
-        {
-            const string ns = "A.B";
-
-            MatchRelevance("D", ns).Should().Be(0);
-            MatchRelevance("D.*", ns).Should().Be(0);
-            MatchRelevance("A.B.C.*", ns).Should().Be(0);
-            MatchRelevance("A", ns).Should().Be(0);
-            MatchRelevance(".", ns).Should().Be(0);
-
-            MatchRelevance("*", ns).Should().BeGreaterThan(0);
-            MatchRelevance("A.*", ns).Should().BeGreaterThan(MatchRelevance("*", ns));
-            MatchRelevance("A.B.*", ns).Should().BeGreaterThan(MatchRelevance("A.*", ns));
-            MatchRelevance("A.B", ns).Should().BeGreaterThan(MatchRelevance("A.B.*", ns));
-        }
-
         [Theory]
-        [InlineData("A.C.D", "A.C.D", 0)]
-        [InlineData("A.C.D", "A.?.D", 1)]
-        [InlineData("A.C.D", "A.C.?", 1)]
-        [InlineData("A.C.D", "?.C.D", 1)]
-        [InlineData("A.C.D", "A.?.?", 2)]
-        [InlineData("A.C.D", "?.?.D", 2)]
-        [InlineData("A.C.D", "?.?.?", 3)]
-        [InlineData("A.C.D", "A.*", 3)]
-        [InlineData("A.C.D", "*.D", 3)]
-        [InlineData("A.C.D", "*.?.D", 3)]
-        [InlineData("A.B.C.D", "*.?.D", 4)]
-        [InlineData("A.C.D", "*", 4)]
-        [InlineData("A.C.D", "B.?.D", int.MaxValue)]
-        [InlineData("A.C.D", "*.E", int.MaxValue)]
-        [InlineData("A.F1.B.C", "A.*.B", int.MaxValue)]
-        [InlineData("A.F1.B.C", "A.*.B.*", 4)]
-        [InlineData("A.F1.B.C", "A.*.B.?", 3)]
-        [InlineData("A.F1.B.C", "A.?.B.?", 2)]
-        [InlineData("A.F1.B.C", "A.?.B.*", 3)]
-        public void VerifyMatchRelevanceWithWildcardSyntax(string ns, string pattern, int distance)
+        [InlineData("A.B", "D", 0)]
+        [InlineData("A.B", "D.*", 0)]
+        [InlineData("A.B", "A.B.C.*", 0)]
+        [InlineData("A.B", "A", 0)]
+        [InlineData("A.B", ".", 0)]
+        [InlineData("A.B", "A.B", int.MaxValue)]
+        [InlineData("A.B", "A.?", int.MaxValue - 1)]
+        [InlineData("A.B", "A.*", int.MaxValue - 2)]
+        [InlineData("A.B", "A.B.*", int.MaxValue - 1)]
+        [InlineData("A.B", "A.B.?", 0)]
+        [InlineData("A.B", "/A\\.B/", 1)]
+        [InlineData("A.B", "/A\\../", 1)]
+        [InlineData("A.B", "/A\\.[A-Z]/", 1)]
+        [InlineData("A.B", "/A\\.[0-9]/", 0)]
+        [InlineData("A.C.D", "B.?.D", 0)]
+        [InlineData("A.C.D", "*.E", 0)]
+        [InlineData("A.C.D", "A.C.D", int.MaxValue)]
+        [InlineData("A.C.D", "A.?.D", int.MaxValue - 1)]
+        [InlineData("A.C.D", "A.C.?", int.MaxValue - 1)]
+        [InlineData("A.C.D", "?.C.D", int.MaxValue - 1)]
+        [InlineData("A.C.D", "A.?.?", int.MaxValue - 2)]
+        [InlineData("A.C.D", "?.?.D", int.MaxValue - 2)]
+        [InlineData("A.C.D", "?.?.?", int.MaxValue - 3)]
+        [InlineData("A.C.D", "A.*", int.MaxValue - 3)]
+        [InlineData("A.C.D", "*.D", int.MaxValue - 3)]
+        [InlineData("A.C.D", "*.?.D", int.MaxValue - 3)]
+        [InlineData("A.B.C.D", "*.?.D", int.MaxValue - 4)]
+        [InlineData("A.C.D", "*", int.MaxValue - 4)]
+        [InlineData("A.F1.B.C", "A.*.B", 0)]
+        [InlineData("A.F1.B.C", "A.*.B.*", int.MaxValue - 4)]
+        [InlineData("A.F1.B.C", "A.*.B.?", int.MaxValue - 3)]
+        [InlineData("A.F1.B.C", "A.?.B.?", int.MaxValue - 2)]
+        [InlineData("A.F1.B.C", "A.?.B.*", int.MaxValue - 3)]
+        public void GetMatchRelevance_ShouldReturnTheExpectedValue(string domainString, string domainSpecificationString, int expectedMatchRelevance)
         {
-            MatchRelevance(pattern, ns).Should().Be(int.MaxValue - distance);
+            var domain = new Domain(domainString);
+            var domainSpecification = DomainSpecificationParser.Parse(domainSpecificationString);
+            domainSpecification.GetMatchRelevance(domain).Should().Be(expectedMatchRelevance);
         }
 
-        private static int MatchRelevance(string domainSpecificationAsString, string domainAsString)
+        /// <summary>
+        /// This test verifies that the matching rules are prioritized correctly, according to their match relevance.
+        /// </summary>
+        [Theory]
+        [InlineData("A.B", "A.B", "A.B.*", "A.?", "A.*", "/A\\.B/")]
+        public void GetMatchRelevance_ShouldPrioritizeProperly(string domainString, params string[] domainSpecificationStrings)
         {
-            var ns = new Domain(domainAsString);
-            return DomainSpecificationParser.Parse(domainSpecificationAsString).GetMatchRelevance(ns);
+            var domain = new Domain(domainString);
+            var domainSpecifications = domainSpecificationStrings.Select(DomainSpecificationParser.Parse);
+            domainSpecifications.Select(i => i.GetMatchRelevance(domain)).Should().BeInDescendingOrder();
         }
     }
 }

--- a/source/NsDepCop.Test/Interface/Config/DomainTests.cs
+++ b/source/NsDepCop.Test/Interface/Config/DomainTests.cs
@@ -25,7 +25,7 @@ namespace Codartis.NsDepCop.Test.Interface.Config
         }
 
         [Fact]
-        public void Create_WithNull_ThrowsArgumentNullExceptionn()
+        public void Create_WithNull_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => new Domain(null));
         }

--- a/source/NsDepCop.Test/Interface/Config/RegexDomainTests.cs
+++ b/source/NsDepCop.Test/Interface/Config/RegexDomainTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Codartis.NsDepCop.Config;
+using FluentAssertions;
+using Xunit;
+
+namespace Codartis.NsDepCop.Test.Interface.Config;
+
+public sealed class RegexDomainTests
+{
+    [Theory]
+    [InlineData("/Unit\\.Test/")]
+    [InlineData("/^Unit\\.Test(\\.[A-Za-z_][A-Za-z0-9_]*)*$/")]
+    public void Create_Works(string regexDomainString)
+    {
+        new RegexDomain(regexDomainString).ToString().Should().Be(regexDomainString);
+    }
+
+    [Fact]
+    public void Create_WithNull_ThrowsArgumentNullExceptionn()
+    {
+        var act = () => new RegexDomain(null);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("//")]
+    [InlineData("^Unit\\.Test(\\.[A-Za-z_][A-Za-z0-9_]*)*$")]
+    [InlineData("/foo{2,1}/")]
+    [InlineData("/(abc\\Kdef)/")]
+    [InlineData("/((a|b|)/")]
+    public void Create_InvalidRegexDomain_ThrowsFormatException(string regexDomainString)
+    {
+        var act = () => new RegexDomain(regexDomainString);
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    [SuppressMessage("ReSharper", "EqualExpressionComparison")]
+    public void Equals_Works()
+    {
+        (new RegexDomain("/Unit\\.Test/") == new RegexDomain("/Unit\\.Test/")).Should().BeTrue();
+        (new RegexDomain("/Unit\\.Test/") == new RegexDomain("/^Unit\\.Test$/")).Should().BeFalse();
+    }
+}

--- a/source/NsDepCop.Test/Interface/Config/RegexDomainTests.cs
+++ b/source/NsDepCop.Test/Interface/Config/RegexDomainTests.cs
@@ -17,7 +17,7 @@ public sealed class RegexDomainTests
     }
 
     [Fact]
-    public void Create_WithNull_ThrowsArgumentNullExceptionn()
+    public void Create_WithNull_ThrowsArgumentNullException()
     {
         var act = () => new RegexDomain(null);
         act.Should().Throw<ArgumentNullException>();
@@ -42,5 +42,14 @@ public sealed class RegexDomainTests
     {
         (new RegexDomain("/Unit\\.Test/") == new RegexDomain("/Unit\\.Test/")).Should().BeTrue();
         (new RegexDomain("/Unit\\.Test/") == new RegexDomain("/^Unit\\.Test$/")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetMatchRelevance_WhenTimeoutOccurs_ShouldReturnNoMatch_WithoutThrowingException()
+    {
+        var rule = new RegexDomain("/(a|aa)+$/", regexTimeout: TimeSpan.FromTicks(1));
+        var domain = new Domain(new string('a', 10));
+        var action = () => rule.GetMatchRelevance(domain);
+        action.Should().NotThrow();
     }
 }

--- a/source/NsDepCop.Test/Interface/Config/WildcardDomainTests.cs
+++ b/source/NsDepCop.Test/Interface/Config/WildcardDomainTests.cs
@@ -22,7 +22,7 @@ namespace Codartis.NsDepCop.Test.Interface.Config
         }
 
         [Fact]
-        public void Create_WithNull_ThrowsArgumentNullExceptionn()
+        public void Create_WithNull_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => new WildcardDomain(null));
         }

--- a/source/NsDepCop.sln
+++ b/source/NsDepCop.sln
@@ -45,6 +45,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NsDepCop.ConfigSchema", "Ns
 		NsDepCop.ConfigSchema\NsDepCopConfig.xsd = NsDepCop.ConfigSchema\NsDepCopConfig.xsd
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NsDepCop.Benchmarks", "NsDepCop.Benchmarks\NsDepCop.Benchmarks.csproj", "{3E9D9807-52F9-4853-A4B5-6AC30AD88D25}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,18 @@ Global
 		{17A44684-B673-42F8-982F-01ABEA3D5BBE}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{17A44684-B673-42F8-982F-01ABEA3D5BBE}.Release|x86.ActiveCfg = Release|Any CPU
 		{17A44684-B673-42F8-982F-01ABEA3D5BBE}.Release|x86.Build.0 = Release|Any CPU
+		{3E9D9807-52F9-4853-A4B5-6AC30AD88D25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E9D9807-52F9-4853-A4B5-6AC30AD88D25}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E9D9807-52F9-4853-A4B5-6AC30AD88D25}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{3E9D9807-52F9-4853-A4B5-6AC30AD88D25}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{3E9D9807-52F9-4853-A4B5-6AC30AD88D25}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3E9D9807-52F9-4853-A4B5-6AC30AD88D25}.Debug|x86.Build.0 = Debug|Any CPU
+		{3E9D9807-52F9-4853-A4B5-6AC30AD88D25}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E9D9807-52F9-4853-A4B5-6AC30AD88D25}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E9D9807-52F9-4853-A4B5-6AC30AD88D25}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{3E9D9807-52F9-4853-A4B5-6AC30AD88D25}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{3E9D9807-52F9-4853-A4B5-6AC30AD88D25}.Release|x86.ActiveCfg = Release|Any CPU
+		{3E9D9807-52F9-4853-A4B5-6AC30AD88D25}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Hi @realvizu 

I tried to integrate Regex support as requested in #53 - this is by far not perfect and needs at least some documentation on the RegexDomain class itself. I tried to adhere some standards as I forced the regex to have a / delimiter at start and end (similiar to js, perletc)

But the two main problems I have - and which I am asking for some help - are the unit-tests and the nuget/dotnet pack execution.

I am running on an osx machine which seems to struggle with some of the commands:

<img width="4936" alt="grafik" src="https://github.com/user-attachments/assets/df54b93b-48c3-4d2b-83ad-6e65662b3794" />

might be some issues with slashes/backslashes in specific os environments...

Maybe you can give me some support in points of issues - and give me some feedback on what I should change in the codebase.

Thanks.