### PR TITLE
Include project config.nsdepcop only if it exists

### DIFF
--- a/source/NsDepCop.NuGet/build/NsDepCop.targets
+++ b/source/NsDepCop.NuGet/build/NsDepCop.targets
@@ -2,7 +2,7 @@
 
   <!-- Adds the config.nsdepcop file as an additial analyzer file if the NsDepCop package is referenced. -->
   <ItemGroup>
-    <AdditionalFiles Include="$(ProjectDir)config.nsdepcop" Condition="@(PackageReference->AnyHaveMetadataValue('Identity','NsDepCop'))=='true'" />
+    <AdditionalFiles Include="$(ProjectDir)config.nsdepcop" Condition="Exists('$(ProjectDir)config.nsdepcop') And @(PackageReference->AnyHaveMetadataValue('Identity','NsDepCop'))=='true'" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Solves #83 

This enables skipping CoreCompile in cases where config.nsdepcop is not next to the project, e. g. because it is defined at a solution level and is manually included as AdditionalFile into all projects. The analyzer itself will still issue a diagnostic in case it does not have any config.nsdepcop, so users will know.

On an unrelated note: what purpose does the existing `Condition` serve? If the targets file is active, the project must have the NsDepCop PackageReference, so why check it?

On yet another unrelated note: with .NET 10 (specifically 10.0.100), `AvoidCycleErrorOnSelfReference` does not work anymore, see https://github.com/NuGet/Home/issues/6754#issuecomment-3451370645