### PR TITLE
Add C# 14 extension member support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NsDepCop Change Log
 
+## v3.0.0
+(06/2026)
+
+- [x] New: Support for C# 14 extension members (requires VS 2026 / .NET 10 SDK).
+- [x] **Breaking:** Minimum toolchain is now VS 2022 17.0 / .NET 6 SDK; older hosts (e.g. VS 2019) no longer load the analyzer — stay on 2.7.x.
+
 ## v2.7.0
 (12/2025)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ See the [**Help**](doc/Help.md) for details.
 
 Or check out this step-by-step [**tutorial video**](https://www.youtube.com/watch?v=rkU7Hx20Dc0) by [plainionist](https://github.com/plainionist).
 
+## Requirements
+
+NsDepCop runs inside the C# compiler, so the **build toolchain** (Visual Studio / .NET SDK) determines compatibility, not the project's target framework:
+
+| NsDepCop | Visual Studio | .NET SDK | Roslyn |
+|---|---|---|---|
+| 3.0+ | 2022 17.0+ | 6.0+ | 4.0+ |
+| 2.7.x and earlier | 2019 16.9+ | 5.0+ | 3.9+ |
+
+> Newer C# syntax is only analyzed when the toolchain's Roslyn supports it — e.g. C# 14 extension members need Roslyn 5+ (VS 2026 / .NET 10 SDK).
+
 ## Versions
 * See the [**Change Log**](CHANGELOG.md) for version history.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
-image: Visual Studio 2022
+image: Visual Studio 2026
 
 environment:
-  shortversion: '2.7.0'
-  informationalversion: '2.7.0'
+  shortversion: '3.0.0'
+  informationalversion: '3.0.0'
 
 version: '$(shortversion).{build}'
 
@@ -30,8 +30,12 @@ build:
   project: source\NsDepCop.sln
   verbosity: minimal
 
-test:
-  assemblies: '**\*Test*.dll'
+# Run the suites against the default (roslyn5.0) analyzer build, then re-run the source tests
+# against the roslyn4.0 build to verify no regression on the older Roslyn (C# 14 tests are gated out there).
+test_script:
+- cmd: dotnet test source\NsDepCop.Test\NsDepCop.Test.csproj -c %CONFIGURATION%
+- cmd: dotnet test source\NsDepCop.SourceTest\NsDepCop.SourceTest.csproj -c %CONFIGURATION%
+- cmd: dotnet test source\NsDepCop.SourceTest\NsDepCop.SourceTest.csproj -c %CONFIGURATION% -p:NsDepCopRoslynVersion=4.0
 
 artifacts:
 - path: 'source\NsDepCop.NuGet\bin\$(configuration)\NsDepCop*.nupkg'

--- a/source/NsDepCop.Analyzer/Directory.Build.props
+++ b/source/NsDepCop.Analyzer/Directory.Build.props
@@ -1,0 +1,24 @@
+<Project>
+
+  <!--
+    Roslyn multi-targeting.
+    The analyzer is built once per supported Roslyn version (see NsDepCopRoslynVersion below), each build
+    referencing a different Microsoft.CodeAnalysis.CSharp version and packaged into its own
+    analyzers/dotnet/roslyn<version>/cs folder. The host compiler selects the highest build it supports.
+
+    Output and intermediate paths must be separated per NsDepCopRoslynVersion so the variants don't clobber
+    each other. These have to be set before the SDK props are imported, hence Directory.Build.props
+    rather than the csproj body.
+  -->
+  <PropertyGroup>
+    <NsDepCopRoslynVersion Condition="'$(NsDepCopRoslynVersion)' == ''">5.0</NsDepCopRoslynVersion>
+    <BaseOutputPath>bin\roslyn$(NsDepCopRoslynVersion)\</BaseOutputPath>
+    <BaseIntermediateOutputPath>obj\roslyn$(NsDepCopRoslynVersion)\</BaseIntermediateOutputPath>
+    <!--
+      Each variant excludes only its own bin/obj by default; exclude the whole trees so the
+      default compile glob never pulls generated .cs (e.g. AssemblyAttributes) from a sibling variant.
+    -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);bin\**;obj\**</DefaultItemExcludes>
+  </PropertyGroup>
+
+</Project>

--- a/source/NsDepCop.Analyzer/NsDepCop.Analyzer.csproj
+++ b/source/NsDepCop.Analyzer/NsDepCop.Analyzer.csproj
@@ -7,6 +7,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <NoWarn>$(NoWarn);RS1036</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNet.Glob" Version="2.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="NsDepCop" Version="2.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/NsDepCop.Analyzer/NsDepCop.Analyzer.csproj
+++ b/source/NsDepCop.Analyzer/NsDepCop.Analyzer.csproj
@@ -8,6 +8,21 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);RS1036</NoWarn>
+    <!-- Bundle DotNet.Glob next to the analyzer so packaging can collect it per Roslyn variant. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <!--
+    Roslyn version selection (NsDepCopRoslynVersion is defined in Directory.Build.props, default 5.0).
+    - 4.0: VS 2022 17.0+ / .NET 6+ SDK. No C# 14 extension-member support.
+    - 5.0: VS 2026 / .NET 10. Full support; ROSLYN5_0_OR_GREATER guards the C# 14-only code.
+  -->
+  <PropertyGroup Condition="'$(NsDepCopRoslynVersion)' == '4.0'">
+    <MicrosoftCodeAnalysisCSharpVersion>4.0.1</MicrosoftCodeAnalysisCSharpVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(NsDepCopRoslynVersion)' == '5.0'">
+    <MicrosoftCodeAnalysisCSharpVersion>5.0.0</MicrosoftCodeAnalysisCSharpVersion>
+    <DefineConstants>$(DefineConstants);ROSLYN5_0_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNet.Glob" Version="2.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
     <PackageReference Include="NsDepCop" Version="2.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/NsDepCop.Analyzer/ParserAdapter/Roslyn/SyntaxNodeAnalyzer.cs
+++ b/source/NsDepCop.Analyzer/ParserAdapter/Roslyn/SyntaxNodeAnalyzer.cs
@@ -112,6 +112,7 @@ namespace Codartis.NsDepCop.ParserAdapter.Roslyn
                 case TypeKind.Unknown:
                 case TypeKind.Submission:
                 case TypeKind.TypeParameter:
+                case TypeKind.Extension:
                     yield break;
 
                 default:
@@ -141,6 +142,8 @@ namespace Codartis.NsDepCop.ParserAdapter.Roslyn
         /// using static A.ClassA;
         /// StaticMethodOfClassA(); // in contrast to A.ClassA.StaticMethodOfClassA();
         /// </code>
+        /// Also handles C# 14 extension members, where the method's containing type has
+        /// <see cref="TypeKind.Extension"/> and its own containing type is the static class.
         /// </summary>
         /// <param name="node">A syntax node representing a static or extension method.</param>
         /// <param name="semanticModel">The semantic model of the project.</param>
@@ -154,7 +157,15 @@ namespace Codartis.NsDepCop.ParserAdapter.Roslyn
                 && (methodSymbol.IsExtensionMethod
                     || (methodSymbol.IsStatic && node.Parent is not MemberAccessExpressionSyntax));
 
-            return isExtensionMethodOrCallOnStaticImport ? methodSymbol.ContainingType : null;
+            if (isExtensionMethodOrCallOnStaticImport)
+                return methodSymbol.ContainingType;
+
+            // C# 14 extension members: the method lives inside an extension block whose TypeKind is Extension.
+            // The dependency is on the enclosing static class, not the block itself.
+            if (methodSymbol?.ContainingType?.TypeKind == TypeKind.Extension)
+                return methodSymbol.ContainingType.ContainingType;
+
+            return null;
         }
 
         /// <summary>
@@ -207,7 +218,14 @@ namespace Codartis.NsDepCop.ParserAdapter.Roslyn
             }
 
             // Determine the type of the type declaration that contains the current syntax node.
-            return semanticModel.GetDeclaredSymbol(typeDeclarationSyntaxNode) as ITypeSymbol;
+            var declaredType = semanticModel.GetDeclaredSymbol(typeDeclarationSyntaxNode) as ITypeSymbol;
+
+            // C# 14 extension blocks are represented as a synthetic extension type.
+            // For dependency ownership, use the enclosing static class.
+            if (declaredType?.TypeKind == TypeKind.Extension)
+                return declaredType.ContainingType;
+
+            return declaredType;
         }
 
         /// <summary>

--- a/source/NsDepCop.Analyzer/ParserAdapter/Roslyn/SyntaxNodeAnalyzer.cs
+++ b/source/NsDepCop.Analyzer/ParserAdapter/Roslyn/SyntaxNodeAnalyzer.cs
@@ -112,7 +112,9 @@ namespace Codartis.NsDepCop.ParserAdapter.Roslyn
                 case TypeKind.Unknown:
                 case TypeKind.Submission:
                 case TypeKind.TypeParameter:
+#if ROSLYN5_0_OR_GREATER
                 case TypeKind.Extension:
+#endif
                     yield break;
 
                 default:
@@ -160,10 +162,12 @@ namespace Codartis.NsDepCop.ParserAdapter.Roslyn
             if (isExtensionMethodOrCallOnStaticImport)
                 return methodSymbol.ContainingType;
 
+#if ROSLYN5_0_OR_GREATER
             // C# 14 extension members: the method lives inside an extension block whose TypeKind is Extension.
             // The dependency is on the enclosing static class, not the block itself.
             if (methodSymbol?.ContainingType?.TypeKind == TypeKind.Extension)
                 return methodSymbol.ContainingType.ContainingType;
+#endif
 
             return null;
         }
@@ -220,10 +224,12 @@ namespace Codartis.NsDepCop.ParserAdapter.Roslyn
             // Determine the type of the type declaration that contains the current syntax node.
             var declaredType = semanticModel.GetDeclaredSymbol(typeDeclarationSyntaxNode) as ITypeSymbol;
 
+#if ROSLYN5_0_OR_GREATER
             // C# 14 extension blocks are represented as a synthetic extension type.
             // For dependency ownership, use the enclosing static class.
             if (declaredType?.TypeKind == TypeKind.Extension)
                 return declaredType.ContainingType;
+#endif
 
             return declaredType;
         }

--- a/source/NsDepCop.Analyzer/RoslynAnalyzer/DiagnosticDefinitions.cs
+++ b/source/NsDepCop.Analyzer/RoslynAnalyzer/DiagnosticDefinitions.cs
@@ -15,7 +15,7 @@ namespace Codartis.NsDepCop.RoslynAnalyzer
 
         public static readonly DiagnosticDescriptor IllegalDependency = CreateDiagnosticDescriptor(
             "NSDEPCOP01",
-            "Illegal namespace reference.",
+            "Illegal namespace reference",
             "Illegal namespace reference: {0}->{1} (Type: {2}->{3}){4}",
             DiagnosticSeverity.Warning,
             "This type cannot reference the other type because their namespaces cannot depend on each other according to the current rules." +
@@ -24,8 +24,8 @@ namespace Codartis.NsDepCop.RoslynAnalyzer
 
         public static readonly DiagnosticDescriptor TooManyDependencyIssues = CreateDiagnosticDescriptor(
             "NSDEPCOP02",
-            "Too many dependency issues, analysis was stopped.",
-            "Maximum dependency issue count ({0}) reached, analysis in this compilation was stopped.",
+            "Too many dependency issues, analysis was stopped",
+            "Maximum dependency issue count ({0}) reached, analysis in this compilation was stopped",
             DiagnosticSeverity.Warning,
             "The number of dependency issues in this compilation has exceeded the configured maximum value." +
             " Correct the reported issues and run the build again or set the MaxIssueCount attribute in your 'config.nsdepcop' file to a higher number."
@@ -33,8 +33,8 @@ namespace Codartis.NsDepCop.RoslynAnalyzer
 
         public static readonly DiagnosticDescriptor NoConfigFile = CreateDiagnosticDescriptor(
             "NSDEPCOP03",
-            "No config file found, analysis skipped.",
-            "No config file found, analysis skipped.",
+            "No config file found, analysis skipped",
+            "No config file found, analysis skipped",
             DiagnosticSeverity.Info,
             "This analyzer requires that you add a file called 'config.nsdepcop' to your project with build action 'C# analyzer additional file'." +
             " If there's no such file, the analyzer skips this project."
@@ -42,15 +42,15 @@ namespace Codartis.NsDepCop.RoslynAnalyzer
 
         public static readonly DiagnosticDescriptor ConfigDisabled = CreateDiagnosticDescriptor(
             "NSDEPCOP04",
-            "Analysis is disabled in the config file.",
-            "Analysis is disabled in the file 'config.nsdepcop'.",
+            "Analysis is disabled in the config file",
+            "Analysis is disabled in the file 'config.nsdepcop'",
             DiagnosticSeverity.Info,
             "The IsEnabled attribute was set to false in this project's 'config.nsdepcop' file, so the analyzer skips this project."
         );
 
         public static readonly DiagnosticDescriptor ConfigException = CreateDiagnosticDescriptor(
             "NSDEPCOP05",
-            "Error loading config.",
+            "Error loading config",
             "Error when loading the file 'config.nsdepcop': {0}",
             DiagnosticSeverity.Error,
             "There was an error while loading the 'config.nsdepcop' file, see the message for details." +
@@ -59,15 +59,15 @@ namespace Codartis.NsDepCop.RoslynAnalyzer
 
         public static readonly DiagnosticDescriptor ToolDisabled = CreateDiagnosticDescriptor(
             "NSDEPCOP06",
-            "Analysis is disabled with environment variable.",
-            $"NsDepCop is disabled with environment variable: '{ProductConstants.DisableToolEnvironmentVariableName}'.",
+            "Analysis is disabled with environment variable",
+            $"NsDepCop is disabled with environment variable: '{ProductConstants.DisableToolEnvironmentVariableName}'",
             DiagnosticSeverity.Info,
             $"If the '{ProductConstants.DisableToolEnvironmentVariableName}' environment variable is set to 'True' or '1' then all analysis is skipped."
         );
 
         public static readonly DiagnosticDescriptor IllegalAssemblyDependency = CreateDiagnosticDescriptor(
             "NSDEPCOP07",
-            "Illegal assembly reference.",
+            "Illegal assembly reference",
             "Illegal assembly reference: {0}->{1}",
             DiagnosticSeverity.Warning,
             "The assembly cannot reference the other assembly because their dependency is prohibited according to the current rules." +

--- a/source/NsDepCop.NuGet/NsDepCop.NuGet.csproj
+++ b/source/NsDepCop.NuGet/NsDepCop.NuGet.csproj
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <PackageId>NsDepCop</PackageId>
-    <PackageVersion>2.7.0-local</PackageVersion>
+    <PackageVersion>3.0.0-local</PackageVersion>
     <Title>NsDepCop - Namespace and Assembly Dependency Checker Tool for C#</Title>
     <Description>NsDepCop is a static code analysis tool that enforces namespace and assembly dependency rules in C# projects.</Description>
     <PackageTags>static code analysis analyzer tool C# csharp namespace type assembly dependency dependencies</PackageTags>
@@ -30,7 +30,8 @@
     <PackageIconUrl>https://raw.githubusercontent.com/realvizu/NsDepCop/master/images/icons/NsDepCop_128.png</PackageIconUrl>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageReleaseNotes>
-- Perf: Avoids unnecessary rebuilds when only a solution-level config.nsdepcop file is used (no project-level files).
+- Added support for C# 14 extension members.
+- BREAKING: The minimum supported build toolchain is now Visual Studio 2022 17.0 / .NET 6 SDK. The analyzer ships Roslyn-version-specific builds (roslyn4.0 and roslyn5.0); hosts older than VS 2022 17.0 / .NET 6 SDK (e.g. VS 2019) no longer load the analyzer. Stay on 2.7.x for those.
 	</PackageReleaseNotes>
   </PropertyGroup>
 
@@ -42,18 +43,34 @@
     <None Update="tools\*.ps1" Pack="true" PackagePath="" />
   </ItemGroup>
 
+  <!--
+    The analyzer is built once per supported Roslyn version and each build is packaged into its own
+    analyzers/dotnet/roslyn<version>/cs folder. Hosts that support Roslyn component versioning
+    (VS 2022 17.0+ / .NET 6+ SDK) pick the highest build they can load; there is intentionally no
+    bare analyzers/dotnet/cs folder, so older hosts load nothing (see release notes for 3.0.0).
+  -->
   <ItemGroup>
-    <ProjectReference Include="..\NsDepCop.Analyzer\NsDepCop.Analyzer.csproj" />
+    <_NsDepCopRoslynVariant Include="4.0" />
+    <_NsDepCopRoslynVariant Include="5.0" />
   </ItemGroup>
 
   <PropertyGroup>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <Target Name="_AddAnalyzersToOutput">
+  <!-- Build every Roslyn variant of the analyzer before packing. -->
+  <Target Name="_BuildAnalyzerVariants">
+    <MSBuild Projects="..\NsDepCop.Analyzer\NsDepCop.Analyzer.csproj"
+             Targets="Restore;Build"
+             Properties="NsDepCopRoslynVersion=%(_NsDepCopRoslynVariant.Identity);Configuration=$(Configuration)" />
+  </Target>
+
+  <Target Name="_AddAnalyzersToOutput" DependsOnTargets="_BuildAnalyzerVariants">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)\NsDepCop.Analyzer.dll" PackagePath="analyzers/dotnet/cs" />
-      <TfmSpecificPackageFile Include="$(OutputPath)\DotNet.Glob.dll" PackagePath="analyzers/dotnet/cs" />
+      <TfmSpecificPackageFile Include="..\NsDepCop.Analyzer\bin\roslyn%(_NsDepCopRoslynVariant.Identity)\$(Configuration)\netstandard2.0\NsDepCop.Analyzer.dll"
+                              PackagePath="analyzers/dotnet/roslyn%(_NsDepCopRoslynVariant.Identity)/cs" />
+      <TfmSpecificPackageFile Include="..\NsDepCop.Analyzer\bin\roslyn%(_NsDepCopRoslynVariant.Identity)\$(Configuration)\netstandard2.0\DotNet.Glob.dll"
+                              PackagePath="analyzers/dotnet/roslyn%(_NsDepCopRoslynVariant.Identity)/cs" />
     </ItemGroup>
   </Target>
 

--- a/source/NsDepCop.SourceTest/Cs14Tests.cs
+++ b/source/NsDepCop.SourceTest/Cs14Tests.cs
@@ -1,3 +1,6 @@
+// C# 14 extension members only exist in Roslyn 5.0+; the source fixture won't even compile on
+// earlier compilers, so this test is built only for the matching analyzer variant.
+#if ROSLYN5_0_OR_GREATER
 using Xunit;
 
 namespace Codartis.NsDepCop.SourceTest
@@ -22,3 +25,4 @@ namespace Codartis.NsDepCop.SourceTest
         }
     }
 }
+#endif

--- a/source/NsDepCop.SourceTest/Cs14Tests.cs
+++ b/source/NsDepCop.SourceTest/Cs14Tests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace Codartis.NsDepCop.SourceTest
+{
+    /// <summary>
+    /// Tests that the analyzer handles C# 14 constructs correctly.
+    /// </summary>
+    /// <remarks>
+    /// The name of the source file and its containing folder is the same as the name of the test.
+    /// </remarks>
+    public class Cs14Tests
+    {
+        [Fact]
+        public void Cs14_ExtensionMembers()
+        {
+            SourceTestSpecification.Create()
+                // new MyClass().MyExtensionMethod() — A depends on B's extension block host type
+                .ExpectInvalidSegment(9, 27, 44)
+                // new MyClass().MyGenericExtensionMethod()
+                .ExpectInvalidSegment(10, 27, 51)
+                .Execute();
+        }
+    }
+}

--- a/source/NsDepCop.SourceTest/Cs14_ExtensionMembers/Cs14_ExtensionMembers.cs
+++ b/source/NsDepCop.SourceTest/Cs14_ExtensionMembers/Cs14_ExtensionMembers.cs
@@ -1,0 +1,35 @@
+﻿namespace A
+{
+    using B;
+
+    class MyClass
+    {
+        void MyMethod()
+        {
+            new MyClass().MyExtensionMethod();
+            new MyClass().MyGenericExtensionMethod();
+        }
+    }
+}
+
+namespace B
+{
+    using A;
+
+    static class MyClassExtensions
+    {
+        extension(MyClass myClass)
+        {
+            public void MyExtensionMethod()
+            {
+            }
+        }
+
+        extension<T>(T t)
+        {
+            public void MyGenericExtensionMethod()
+            {
+            }
+        }
+    }
+}

--- a/source/NsDepCop.SourceTest/Cs14_ExtensionMembers/config.nsdepcop
+++ b/source/NsDepCop.SourceTest/Cs14_ExtensionMembers/config.nsdepcop
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<NsDepCopConfig>
+    <Allowed From="*" To="System" />
+    <Allowed From="B" To="A" />
+</NsDepCopConfig>

--- a/source/NsDepCop.SourceTest/NsDepCop.SourceTest.csproj
+++ b/source/NsDepCop.SourceTest/NsDepCop.SourceTest.csproj
@@ -291,6 +291,9 @@
     <None Update="AnalyzerFeature_ParentCanDependOnChildImplicitly\config.nsdepcop">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Cs14_ExtensionMembers\Cs14_ExtensionMembers.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>
@@ -418,6 +421,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Cs7_Tuples\config.nsdepcop">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Cs14_ExtensionMembers\config.nsdepcop">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/source/NsDepCop.SourceTest/NsDepCop.SourceTest.csproj
+++ b/source/NsDepCop.SourceTest/NsDepCop.SourceTest.csproj
@@ -9,6 +9,14 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <!--
+    Matches the analyzer's NsDepCopRoslynVersion (flows in as a global property when building a specific
+    variant; empty/default means the newest). Gates the C# 14 source tests to the 5.0 build.
+  -->
+  <PropertyGroup Condition="'$(NsDepCopRoslynVersion)' != '4.0'">
+    <DefineConstants>$(DefineConstants);ROSLYN5_0_OR_GREATER</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Include\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
     <Compile Include="..\Include\VersionInfo.cs" Link="Properties\VersionInfo.cs" />


### PR DESCRIPTION
I noticed that I was not getting any rule violations for [C# 14 extension members](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#extension-members) so I have opened this PR to address that.

Roslyn 5.x's RS1031/RS1032 rules (stricter in the new SDK) required titles with no trailing period and single-sentence messages with no trailing period. So I have removed the trailing `.` from all 7 diagnostic titles and 4 message strings.

I have also added `<NoWarn>RS1036</NoWarn>` to suppresses the new "set EnforceExtendedAnalyzerRules" warning without banning the file I/O the analyser legitimately needs.