### PR TITLE
Add named placeholders to dependency rules

### DIFF
--- a/doc/Help.md
+++ b/doc/Help.md
@@ -182,7 +182,7 @@ App.[M].* | App.A.B.C | yes | M = A
 <Disallowed From="[Module].*" To="[!Module].Domain.*" />
 ```
 * Placeholders are bound **by name, not by position**: the `To` side may reference them in any order (eg. `From="App.[P1].[P2].*" To="App.[P2].[P1].*"` swaps the two segments), repeat a name, or use only a subset of the `From` side's placeholders.
-* A placeholder that appears only on the `From` side is valid; the captured value is simply unused and the placeholder behaves like the corresponding wildcard. The reverse is not valid: see below.
+* A placeholder that appears only on the `From` side is valid; the captured value is simply unused. It still matches like the corresponding wildcard (`[Name]` like `?`, `[Name*]` like `*`), except that `[Name*]` keeps requiring **at least one** component — it never matches zero, regardless of the `To` side. The reverse is not valid: see below.
 * Placeholders can be mixed with the `?` and `*` wildcards; those match as usual but do not capture.
 * Validity rules (violations are reported as a config error):
   * Placeholder names on the `From` side must be unique.

--- a/doc/Help.md
+++ b/doc/Help.md
@@ -29,6 +29,7 @@ Namespace specification type | Example
 Exact| System.IO
 Wildcard | System.Collections.* <br> MyProduct.?.StorageModel
 Regex | /MyProduct(\.[\w]+)*\.StorageModel[\w]/
+Placeholder | MyProduct.[Module].StorageModel <br> See [Placeholders](#placeholders).
 
 > Notice that Regex patterns must be enclosed in forward slashes ('/').
 
@@ -138,6 +139,61 @@ The best matching rule is the one with the minimal edit distance between namespa
 * Replacing a `*` has a cost of 1 and additionaly a cost of 1 per sub-namespace that replaces the `*`.
 
 Example: When matching the namespace `A.B.C.D` the rule `A.?.?.D` (edit distance = 2) is preferred to the rule `A.*.D` (edit distance = 3). If multiple rules have the same edit distance, the behavior is undefined.
+
+### Placeholders
+* Placeholders link the `From` and the `To` side of a rule: a placeholder **captures** namespace components on the `From` side, and the `To` side refers to the **captured value**.
+* This makes rule sets module-agnostic. Say each component's `Services` may depend only on **its own** `Domain`:
+```
+A.Services -> A.Domain
+B.Services -> B.Domain
+C.Services -> C.Domain
+```
+Instead of one rule per component (which has to be extended whenever a component is added), a single rule expresses all of them:
+```xml
+<Allowed From="[Module].Services" To="[Module].Domain" />
+```
+Wildcards cannot express this because the two sides match independently: `<Allowed From="?.Services" To="?.Domain" />` would also allow `A.Services` -> `B.Domain`. The same applies to Regex rules: the two patterns are evaluated in separate matches, so a capture on the `From` side cannot be referenced on the `To` side.
+
+Notation | Meaning
+-- | --
+[Name] | Matches and captures exactly one namespace component (like `?`).
+[Name*] | Matches and captures one or more namespace components (like `*`, but at least one).
+[!Name] | Valid only on the `To` side. Matches exactly one component that is NOT equal to the value captured for `Name` on the `From` side.
+
+* How a `From`-side pattern matches and captures:
+
+Pattern | Namespace | Match? | Captured value(s)
+-- | -- | -- | --
+[M].C | A.C | yes | M = A
+[M].C | A.B.C | no ([M] matches exactly one component) |
+[M*].C | A.B.C | yes | M = A.B
+[M*].C | C | no ([M*] matches at least one component) |
+App.[M].* | App.A.B.C | yes | M = A
+[M].[N*].D | A.B.C.D | yes | M = A, N = B.C
+
+* On the `To` side the captured value replaces the placeholder before matching. With the rule `<Allowed From="[Module].Services" To="[Module].Domain.*" />` the dependency `A.Services` -> `A.Domain.Entities` matches (the `To` side becomes `A.Domain.*`), while `A.Services` -> `B.Domain.Entities` does not.
+* Multiple placeholders can be combined. Example: allow every component to use a shared area, but only **within the same layer**:
+```xml
+<Allowed From="App.[Module].[Layer].*" To="App.Shared.[Layer].*" />
+```
+* A multi placeholder captures a whole sub-path as one value, which covers nested components: `<Allowed From="App.[Path*].Services" To="App.[Path*].Domain" />` allows `App.A.B.Services` -> `App.A.B.Domain` (captured value: `A.B`) but not -> `App.A.Domain`: the complete captured sub-path must reappear on the `To` side.
+* A negated placeholder expresses **inequality** and is typically used in `Disallowed` rules. The following rule forbids using **another** component's `Domain`, even if a broad `Allowed` rule (eg. inherited from a parent config) would otherwise permit it:
+```xml
+<Disallowed From="[Module].*" To="[!Module].Domain.*" />
+```
+* Placeholders are bound **by name, not by position**: the `To` side may reference them in any order (eg. `From="App.[P1].[P2].*" To="App.[P2].[P1].*"` swaps the two segments), repeat a name, or use only a subset of the `From` side's placeholders.
+* A placeholder that appears only on the `From` side is valid; the captured value is simply unused and the placeholder behaves like the corresponding wildcard. The reverse is not valid: see below.
+* Placeholders can be mixed with the `?` and `*` wildcards; those match as usual but do not capture.
+* Validity rules (violations are reported as a config error):
+  * Placeholder names on the `From` side must be unique.
+  * Every placeholder on the `To` side (including negated ones) must also occur on the `From` side.
+  * `[!Name]` must not refer to a multi placeholder (`[Name*]`), and `[!Name*]` is not valid.
+  * Two adjacent multi-matching tokens (`*` or `[Name*]`) are not allowed, mirroring the rule that forbids `*.*`.
+* When several capture lengths are possible (eg. `[A*].[B]` matching `X.Y.Z`), the leftmost placeholder captures as few components as possible; there is no backtracking over alternative splits against the `To` side. Place a literal component between multi-matching tokens to avoid the ambiguity altogether.
+* When selecting the best matching rule, a placeholder counts like the corresponding wildcard: `[Name]` like `?`, `[Name*]` like `*` (see the edit distance calculation above).
+* Placeholders can also be used in assembly dependency rules.
+
+> Notice that a namespace specification containing '[' is interpreted as a placeholder specification, unless it is enclosed in forward slashes ('/'), in which case it is a Regex.
 
 ### Namespace surface
 * The *surface* of a namespace consists of the types that are visible to some other namespace.

--- a/source/NsDepCop.Analyzer/Analysis/Implementation/AssemblyDependencyValidator.cs
+++ b/source/NsDepCop.Analyzer/Analysis/Implementation/AssemblyDependencyValidator.cs
@@ -44,13 +44,13 @@ namespace Codartis.NsDepCop.Analysis.Implementation
         private DependencyRule GetMostSpecificAllowRule(Domain from, Domain to)
         {
             return _allowRules
-                .Where(element => element.From.Matches(from) && element.To.Matches(to))
-                .MaxByOrDefault(element => element.From.GetMatchRelevance(from));
+                .Where(element => element.Matches(from, to))
+                .MaxByOrDefault(element => element.GetFromMatchRelevance(from));
         }
 
         private DependencyRule GetDisallowRule(Domain from, Domain to)
         {
-            return _disallowRules.FirstOrDefault(element => element.From.Matches(from) && element.To.Matches(to));
+            return _disallowRules.FirstOrDefault(element => element.Matches(from, to));
         }
     }
 }

--- a/source/NsDepCop.Analyzer/Analysis/Implementation/TypeDependencyValidator.cs
+++ b/source/NsDepCop.Analyzer/Analysis/Implementation/TypeDependencyValidator.cs
@@ -78,14 +78,14 @@ namespace Codartis.NsDepCop.Analysis.Implementation
         private DependencyRule GetMostSpecificAllowRule(Domain from, Domain to)
         {
             return _allowRules.Keys
-                .Where(i => i.From.Matches(from) && i.To.Matches(to))
-                .MaxByOrDefault(i => i.From.GetMatchRelevance(from));
+                .Where(i => i.Matches(from, to))
+                .MaxByOrDefault(i => i.GetFromMatchRelevance(from));
         }
 
         private DependencyRule GetDisallowRule(Domain from, Domain to)
         {
             return _disallowRules
-                .FirstOrDefault(i => i.From.Matches(from) && i.To.Matches(to));
+                .FirstOrDefault(i => i.Matches(from, to));
         }
 
         private TypeNameSet GetVisibleMembers(DependencyRule allowRule, Domain targetNamespace)

--- a/source/NsDepCop.Analyzer/Config/DependencyRule.cs
+++ b/source/NsDepCop.Analyzer/Config/DependencyRule.cs
@@ -68,7 +68,7 @@ namespace Codartis.NsDepCop.Config
         /// <param name="from">The source domain of the dependency.</param>
         /// <param name="to">The target domain of the dependency.</param>
         /// <returns>True if this rule matches the given domain pair.</returns>
-        public virtual bool Matches(Domain from, Domain to)
+        public bool Matches(Domain from, Domain to)
         {
             if (From is PlaceholderDomain fromPlaceholder)
             {
@@ -103,7 +103,7 @@ namespace Codartis.NsDepCop.Config
         /// </summary>
         /// <param name="from">The source domain of the dependency.</param>
         /// <returns>Zero means no match. Higher value means more relevant match.</returns>
-        public virtual int GetFromMatchRelevance(Domain from) => From.GetMatchRelevance(from);
+        public int GetFromMatchRelevance(Domain from) => From.GetMatchRelevance(from);
 
         private DomainSpecification GetSubstitutedToSpecification(
             PlaceholderDomain toPlaceholder,

--- a/source/NsDepCop.Analyzer/Config/DependencyRule.cs
+++ b/source/NsDepCop.Analyzer/Config/DependencyRule.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Threading;
 
 namespace Codartis.NsDepCop.Config
 {
@@ -13,6 +17,13 @@ namespace Codartis.NsDepCop.Config
     [Serializable]
     public class DependencyRule
     {
+        /// <summary>
+        /// Caches the domain specifications created by substituting captured placeholder values
+        /// into the 'To' side, keyed by the substituted string.
+        /// Not serialized; recreated on demand after deserialization.
+        /// </summary>
+        [NonSerialized] private ConcurrentDictionary<string, DomainSpecification> _substitutedToSpecificationCache;
+
         /// <summary>
         /// The dependency points from this domain to the other.
         /// </summary>
@@ -32,6 +43,8 @@ namespace Codartis.NsDepCop.Config
         {
             From = from ?? throw new ArgumentNullException(nameof(from));
             To = to ?? throw new ArgumentNullException(nameof(to));
+
+            ValidatePlaceholderUsage(From, To);
         }
 
         /// <summary>
@@ -42,6 +55,93 @@ namespace Codartis.NsDepCop.Config
         public DependencyRule(string from, string to)
             : this(DomainSpecificationParser.Parse(from), DomainSpecificationParser.Parse(to))
         { }
+
+        /// <summary>
+        /// Returns a value indicating whether this rule matches the given (from, to) domain pair.
+        /// </summary>
+        /// <remarks>
+        /// For rules without placeholders this is equivalent to matching both sides independently.
+        /// If both sides are <see cref="PlaceholderDomain"/>s, the values captured on the 'From' side
+        /// are applied to the 'To' side before matching it, which links the two sides: positive
+        /// placeholders are substituted with the captured value, negated placeholders must differ from it.
+        /// </remarks>
+        /// <param name="from">The source domain of the dependency.</param>
+        /// <param name="to">The target domain of the dependency.</param>
+        /// <returns>True if this rule matches the given domain pair.</returns>
+        public virtual bool Matches(Domain from, Domain to)
+        {
+            if (From is PlaceholderDomain fromPlaceholder && To is PlaceholderDomain toPlaceholder)
+            {
+                if (!fromPlaceholder.TryMatch(from, out var capturedValues))
+                    return false;
+
+                // Negated placeholders ('[!Name]') have no substitution semantics,
+                // so the 'To' side is matched directly against the captured bindings.
+                return toPlaceholder.HasNegatedPlaceholders
+                    ? toPlaceholder.Matches(to, capturedValues)
+                    : GetSubstitutedToSpecification(toPlaceholder, capturedValues).Matches(to);
+            }
+
+            return From.Matches(from) && To.Matches(to);
+        }
+
+        /// <summary>
+        /// Returns a number indicating how well the 'From' side of this rule matches the given domain.
+        /// Used to select the most specific rule among all matching rules.
+        /// </summary>
+        /// <param name="from">The source domain of the dependency.</param>
+        /// <returns>Zero means no match. Higher value means more relevant match.</returns>
+        public virtual int GetFromMatchRelevance(Domain from) => From.GetMatchRelevance(from);
+
+        private DomainSpecification GetSubstitutedToSpecification(
+            PlaceholderDomain toPlaceholder,
+            IReadOnlyDictionary<string, string> capturedValues)
+        {
+            var substituted = toPlaceholder.Substitute(capturedValues);
+
+            var cache = LazyInitializer.EnsureInitialized(ref _substitutedToSpecificationCache);
+
+            // The substituted string contains no placeholders anymore, so the parser
+            // yields a Domain or (if '?'/'*' wildcards remain) a WildcardDomain.
+            return cache.GetOrAdd(substituted, static s => DomainSpecificationParser.Parse(s));
+        }
+
+        private static void ValidatePlaceholderUsage(DomainSpecification from, DomainSpecification to)
+        {
+            var fromTokens = (from as PlaceholderDomain)?.PlaceholderTokens.ToList()
+                             ?? new List<(string Name, bool IsMulti, bool IsNegated)>();
+
+            if (fromTokens.Any(t => t.IsNegated))
+                throw new FormatException($"Negated placeholders are not allowed on the 'From' side ('{from}').");
+
+            var fromPlaceholderNames = fromTokens.Select(t => t.Name).ToList();
+
+            if (fromPlaceholderNames.Count != fromPlaceholderNames.Distinct().Count())
+                throw new FormatException($"Placeholder names in '{from}' must be unique.");
+
+            if (to is PlaceholderDomain toPlaceholder)
+            {
+                var toTokens = toPlaceholder.PlaceholderTokens.ToList();
+
+                var unboundNames = toTokens.Select(t => t.Name).Distinct().Except(fromPlaceholderNames).ToList();
+                if (unboundNames.Count > 0)
+                    throw new FormatException(
+                        $"Placeholder(s) {string.Join(", ", unboundNames)} in '{to}' are not bound by '{from}'.");
+
+                // A negated reference compares exactly one component, so it must refer
+                // to a single-component capture ('[Name]'), not a multi capture ('[Name*]').
+                var fromMultiNames = fromTokens.Where(t => t.IsMulti).Select(t => t.Name).ToList();
+                var invalidNegatedNames = toTokens
+                    .Where(t => t.IsNegated && fromMultiNames.Contains(t.Name))
+                    .Select(t => t.Name)
+                    .Distinct()
+                    .ToList();
+
+                if (invalidNegatedNames.Count > 0)
+                    throw new FormatException(
+                        $"Negated placeholder(s) {string.Join(", ", invalidNegatedNames)} in '{to}' must not refer to multi placeholders in '{from}'.");
+            }
+        }
 
         /// <summary>
         /// Returns the string representation of a namespace dependency.

--- a/source/NsDepCop.Analyzer/Config/DependencyRule.cs
+++ b/source/NsDepCop.Analyzer/Config/DependencyRule.cs
@@ -70,16 +70,28 @@ namespace Codartis.NsDepCop.Config
         /// <returns>True if this rule matches the given domain pair.</returns>
         public virtual bool Matches(Domain from, Domain to)
         {
-            if (From is PlaceholderDomain fromPlaceholder && To is PlaceholderDomain toPlaceholder)
+            if (From is PlaceholderDomain fromPlaceholder)
             {
+                // Always match the 'From' side with placeholder semantics ('[Name*]' captures one or
+                // more components), never the wildcard-degraded relevance (where '*' also matches zero).
+                // This keeps a placeholder's meaning independent of what is on the 'To' side.
                 if (!fromPlaceholder.TryMatch(from, out var capturedValues))
                     return false;
 
-                // Negated placeholders ('[!Name]') have no substitution semantics,
-                // so the 'To' side is matched directly against the captured bindings.
-                return toPlaceholder.HasNegatedPlaceholders
-                    ? toPlaceholder.Matches(to, capturedValues)
-                    : GetSubstitutedToSpecification(toPlaceholder, capturedValues).Matches(to);
+                // If the 'To' side has placeholders too, link the two sides via the captured values.
+                // (A 'To'-side placeholder is only reachable when the 'From' side has one, so this
+                // is the only place the link can occur.)
+                if (To is PlaceholderDomain toPlaceholder)
+                {
+                    // Negated placeholders ('[!Name]') have no substitution semantics,
+                    // so the 'To' side is matched directly against the captured bindings.
+                    return toPlaceholder.HasNegatedPlaceholders
+                        ? toPlaceholder.Matches(to, capturedValues)
+                        : GetSubstitutedToSpecification(toPlaceholder, capturedValues).Matches(to);
+                }
+
+                // Placeholder only on the 'From' side: the captured values are unused; match 'To' independently.
+                return To.Matches(to);
             }
 
             return From.Matches(from) && To.Matches(to);

--- a/source/NsDepCop.Analyzer/Config/Domain.cs
+++ b/source/NsDepCop.Analyzer/Config/Domain.cs
@@ -36,6 +36,10 @@ namespace Codartis.NsDepCop.Config
                 : 0;
         }
 
+        /// <inheritdoc />
+        /// <remarks>A concrete domain always denotes exactly one namespace.</remarks>
+        public override bool ResolvesToSingleDomainPerMatch => true;
+
         /// <summary>
         /// Determines whether this domain is a sub-domain of the given other one.
         /// </summary>

--- a/source/NsDepCop.Analyzer/Config/Domain.cs
+++ b/source/NsDepCop.Analyzer/Config/Domain.cs
@@ -41,6 +41,14 @@ namespace Codartis.NsDepCop.Config
         public override bool ResolvesToSingleDomainPerMatch => true;
 
         /// <summary>
+        /// Splits this domain into its name components. Empty components are dropped, so the
+        /// global domain ('.') decomposes to zero components (it has no name parts) and therefore
+        /// never spuriously matches a pattern that requires at least one component.
+        /// </summary>
+        internal string[] ToComponents()
+            => ToString().Split([DomainPartSeparator], StringSplitOptions.RemoveEmptyEntries);
+
+        /// <summary>
         /// Determines whether this domain is a sub-domain of the given other one.
         /// </summary>
         /// <param name="parentCandidate">The domain to test whether it's a parent of the current domain.</param>

--- a/source/NsDepCop.Analyzer/Config/DomainSpecification.cs
+++ b/source/NsDepCop.Analyzer/Config/DomainSpecification.cs
@@ -48,6 +48,13 @@ namespace Codartis.NsDepCop.Config
         /// <returns>True if this domain specification matches the given domain.</returns>
         public bool Matches(Domain domain) => GetMatchRelevance(domain) > 0;
 
+        /// <summary>
+        /// True if this specification identifies exactly one concrete domain whenever it matches,
+        /// so an inline set of visible members can be attributed unambiguously to a single target namespace.
+        /// Patterns that can match more than one domain (eg. wildcard or regex specifications) return false.
+        /// </summary>
+        public virtual bool ResolvesToSingleDomainPerMatch => false;
+
         public override string ToString() => Value;
 
         public bool Equals(DomainSpecification other)

--- a/source/NsDepCop.Analyzer/Config/DomainSpecificationParser.cs
+++ b/source/NsDepCop.Analyzer/Config/DomainSpecificationParser.cs
@@ -17,6 +17,10 @@ namespace Codartis.NsDepCop.Config
         {
             if (domainSpecificationAsString.StartsWith(RegexDomain.Delimiter) && domainSpecificationAsString.EndsWith(RegexDomain.Delimiter))
                 return new RegexDomain(domainSpecificationAsString);
+            // Must be checked before the wildcard branch because '[Name*]' also contains '*'.
+            // Must be checked after the regex branch because regex character classes also contain '['.
+            if (domainSpecificationAsString.Contains(PlaceholderDomain.PlaceholderStartMarker))
+                return new PlaceholderDomain(domainSpecificationAsString);
             if (domainSpecificationAsString.Contains(WildcardDomain.SingleDomainMarker) || domainSpecificationAsString.Contains(WildcardDomain.AnyDomainMarker))
                 return new WildcardDomain(domainSpecificationAsString);
             return new Domain(domainSpecificationAsString);

--- a/source/NsDepCop.Analyzer/Config/Implementation/XmlConfigParser.cs
+++ b/source/NsDepCop.Analyzer/Config/Implementation/XmlConfigParser.cs
@@ -149,8 +149,8 @@ namespace Codartis.NsDepCop.Config.Implementation
             if (visibleMembersChild == null)
                 return null;
 
-            if (allowedRule.To is not Domain)
-                throw new Exception($"{GetLineInfo(element)}The target namespace '{allowedRule.To}' must be a single namespace.");
+            if (!allowedRule.To.ResolvesToSingleDomainPerMatch)
+                throw new Exception($"{GetLineInfo(element)}The target namespace '{allowedRule.To}' must resolve to a single namespace.");
 
             if (visibleMembersChild.Attribute(OfNamespaceAttributeName) != null)
                 throw new Exception(

--- a/source/NsDepCop.Analyzer/Config/Implementation/XmlConfigParser.cs
+++ b/source/NsDepCop.Analyzer/Config/Implementation/XmlConfigParser.cs
@@ -187,7 +187,9 @@ namespace Codartis.NsDepCop.Config.Implementation
             var from = TryAndReportError(element, () => DomainSpecificationParser.Parse(fromValue.Trim()));
             var to = TryAndReportError(element, () => DomainSpecificationParser.Parse(toValue.Trim()));
 
-            return new DependencyRule(from, to);
+            // Wrapped so that rule-level validation errors (eg. an unbound placeholder)
+            // are reported with line info, just like side-level parse errors.
+            return TryAndReportError(element, () => new DependencyRule(from, to));
         }
 
         private static DependencyRule ParseAssemblyDependencyRule(XElement element)
@@ -203,7 +205,7 @@ namespace Codartis.NsDepCop.Config.Implementation
             var from = TryAndReportError(element, () => DomainSpecificationParser.Parse(fromValue.Trim()));
             var to = TryAndReportError(element, () => DomainSpecificationParser.Parse(toValue.Trim()));
 
-            return new DependencyRule(from, to);
+            return TryAndReportError(element, () => new DependencyRule(from, to));
         }
 
         private static T TryAndReportError<T>(XObject xObject, Func<T> parserDelegate)

--- a/source/NsDepCop.Analyzer/Config/PlaceholderDomain.cs
+++ b/source/NsDepCop.Analyzer/Config/PlaceholderDomain.cs
@@ -183,7 +183,7 @@ namespace Codartis.NsDepCop.Config
         /// <returns>True if the domain matches this specification.</returns>
         public bool TryMatch(Domain domain, out IReadOnlyDictionary<string, string> capturedValues)
         {
-            var actualComponents = domain.ToString().Split(DomainPartSeparator);
+            var actualComponents = domain.ToComponents();
             var captures = new Dictionary<string, string>();
 
             if (TryMatchRecursive(actualComponents, GetTokens(), captures, boundValues: null))
@@ -209,7 +209,7 @@ namespace Codartis.NsDepCop.Config
             if (boundValues == null)
                 throw new ArgumentNullException(nameof(boundValues));
 
-            var actualComponents = domain.ToString().Split(DomainPartSeparator);
+            var actualComponents = domain.ToComponents();
 
             return TryMatchRecursive(actualComponents, GetTokens(), captures: null, boundValues);
         }

--- a/source/NsDepCop.Analyzer/Config/PlaceholderDomain.cs
+++ b/source/NsDepCop.Analyzer/Config/PlaceholderDomain.cs
@@ -1,0 +1,451 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Codartis.NsDepCop.Config
+{
+    /// <summary>
+    /// Represents a domain specification with named placeholders, eg. 'MyApp.[Module].Domain'.
+    /// <br/>
+    /// A placeholder used on the 'From' side of a dependency rule captures the matched domain component(s);
+    /// the same placeholder on the 'To' side is substituted with the captured value before matching.
+    /// <ul>
+    /// <li>'[Name]' matches and captures exactly one domain component (like '?').</li>
+    /// <li>'[Name*]' matches and captures one or more domain components (like '*', but at least one).</li>
+    /// <li>'[!Name]' (only valid on the 'To' side) matches exactly one component that is NOT equal
+    /// to the value captured for 'Name' on the 'From' side.</li>
+    /// <li>Regular '?' and '*' wildcards may be mixed in; they match but do not capture.</li>
+    /// </ul>
+    /// When several capture lengths are possible (eg. '[A*].[B]'), the leftmost placeholder
+    /// captures as few components as possible (shortest-first, deterministic).
+    /// <br/>
+    /// This class is immutable.
+    /// </summary>
+    [Serializable]
+    public sealed class PlaceholderDomain : DomainSpecification
+    {
+        public const string PlaceholderStartMarker = "[";
+        public const string PlaceholderEndMarker = "]";
+        public const string PlaceholderNegationMarker = "!";
+
+        private static readonly Regex PlaceholderTokenRegex =
+            new Regex(@"^\[(?<negated>!)?(?<name>[A-Za-z_][A-Za-z0-9_]*)(?<multi>\*)?\]$", RegexOptions.Compiled);
+
+        private readonly string[] _components;
+
+        private enum TokenKind
+        {
+            Literal,
+            SingleWildcard,
+            AnyWildcard,
+            Placeholder
+        }
+
+        /// <summary>
+        /// A pre-parsed pattern component, so that the match path needs no Regex evaluation.
+        /// </summary>
+        private readonly struct Token
+        {
+            public readonly TokenKind Kind;
+            public readonly string Text;
+            public readonly string Name;
+            public readonly bool IsMulti;
+            public readonly bool IsNegated;
+
+            public Token(TokenKind kind, string text, string name, bool isMulti, bool isNegated)
+            {
+                Kind = kind;
+                Text = text;
+                Name = name;
+                IsMulti = isMulti;
+                IsNegated = isNegated;
+            }
+        }
+
+        /// <summary>
+        /// The pre-parsed pattern components.
+        /// Not serialized; recreated on demand after deserialization.
+        /// </summary>
+        [NonSerialized] private Token[] _tokens;
+
+        /// <summary>
+        /// Lazily created equivalent where placeholders are degraded to plain wildcards
+        /// ('[Name]' -> '?', '[Name*]' -> '*'). Used for match relevance calculation.
+        /// Not serialized; recreated on demand after deserialization.
+        /// </summary>
+        [NonSerialized] private WildcardDomain _degradedWildcardDomain;
+
+        /// <summary>
+        /// Creates a new instance from a string representation.
+        /// </summary>
+        /// <param name="placeholderDomainAsString">The string representation of a domain pattern containing placeholders.</param>
+        /// <param name="validate">True means validate the input string.</param>
+        public PlaceholderDomain(string placeholderDomainAsString, bool validate = true)
+            : base(placeholderDomainAsString, validate, IsValid)
+        {
+            _components = placeholderDomainAsString.Split(DomainPartSeparator);
+            _tokens = ParseTokens(_components);
+        }
+
+        private Token[] GetTokens() => _tokens ??= ParseTokens(_components);
+
+        private static Token[] ParseTokens(string[] components)
+        {
+            var tokens = new Token[components.Length];
+
+            for (var i = 0; i < components.Length; i++)
+            {
+                var component = components[i];
+
+                if (component == WildcardDomain.SingleDomainMarker)
+                    tokens[i] = new Token(TokenKind.SingleWildcard, component, null, false, false);
+                else if (component == WildcardDomain.AnyDomainMarker)
+                    tokens[i] = new Token(TokenKind.AnyWildcard, component, null, false, false);
+                else if (TryParsePlaceholderToken(component, out var name, out var isMulti, out var isNegated))
+                    tokens[i] = new Token(TokenKind.Placeholder, component, name, isMulti, isNegated);
+                else
+                    tokens[i] = new Token(TokenKind.Literal, component, null, false, false);
+            }
+
+            return tokens;
+        }
+
+        /// <summary>
+        /// All placeholder tokens in order of appearance. Names may appear multiple times
+        /// (allowed on the 'To' side, rejected on the 'From' side by <see cref="DependencyRule"/>).
+        /// </summary>
+        public IEnumerable<(string Name, bool IsMulti, bool IsNegated)> PlaceholderTokens
+        {
+            get
+            {
+                foreach (var token in GetTokens())
+                {
+                    if (token.Kind == TokenKind.Placeholder)
+                        yield return (token.Name, token.IsMulti, token.IsNegated);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The names of all placeholders (including negated references) in order of appearance.
+        /// </summary>
+        public IEnumerable<string> PlaceholderNames
+        {
+            get
+            {
+                foreach (var token in PlaceholderTokens)
+                    yield return token.Name;
+            }
+        }
+
+        /// <summary>
+        /// True if this specification contains at least one negated placeholder ('[!Name]').
+        /// </summary>
+        public bool HasNegatedPlaceholders
+        {
+            get
+            {
+                foreach (var token in PlaceholderTokens)
+                {
+                    if (token.IsNegated)
+                        return true;
+                }
+
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Relevance is defined as the relevance of the wildcard-degraded equivalent,
+        /// so 'A.[M].B' is exactly as relevant as 'A.?.B'.
+        /// </remarks>
+        public override int GetMatchRelevance(Domain domain)
+        {
+            return GetDegradedWildcardDomain().GetMatchRelevance(domain);
+        }
+
+        /// <summary>
+        /// Matches this specification against a concrete domain and extracts the placeholder captures.
+        /// </summary>
+        /// <param name="domain">A concrete domain.</param>
+        /// <param name="capturedValues">On success: placeholder name -> captured domain component(s), dot-separated for multi captures.</param>
+        /// <returns>True if the domain matches this specification.</returns>
+        public bool TryMatch(Domain domain, out IReadOnlyDictionary<string, string> capturedValues)
+        {
+            var actualComponents = domain.ToString().Split(DomainPartSeparator);
+            var captures = new Dictionary<string, string>();
+
+            if (TryMatchRecursive(actualComponents, GetTokens(), captures, boundValues: null))
+            {
+                capturedValues = captures;
+                return true;
+            }
+
+            capturedValues = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Matches this specification against a concrete domain using values that were captured
+        /// on the 'From' side of a dependency rule. Placeholders compare against their bound value
+        /// ('[Name]' must equal it, '[!Name]' must differ from it); nothing is captured.
+        /// </summary>
+        /// <param name="domain">A concrete domain.</param>
+        /// <param name="boundValues">Placeholder name -> value captured on the 'From' side.</param>
+        /// <returns>True if the domain matches this specification under the given bindings.</returns>
+        public bool Matches(Domain domain, IReadOnlyDictionary<string, string> boundValues)
+        {
+            if (boundValues == null)
+                throw new ArgumentNullException(nameof(boundValues));
+
+            var actualComponents = domain.ToString().Split(DomainPartSeparator);
+
+            return TryMatchRecursive(actualComponents, GetTokens(), captures: null, boundValues);
+        }
+
+        /// <summary>
+        /// Replaces every placeholder with its captured value and returns the resulting
+        /// domain specification string. The result may still contain '?' and '*' wildcards.
+        /// </summary>
+        /// <param name="capturedValues">Placeholder name -> captured value.</param>
+        /// <returns>The substituted domain specification string.</returns>
+        public string Substitute(IReadOnlyDictionary<string, string> capturedValues)
+        {
+            if (capturedValues == null)
+                throw new ArgumentNullException(nameof(capturedValues));
+
+            var resultComponents = new string[_components.Length];
+
+            var tokens = GetTokens();
+
+            for (var i = 0; i < tokens.Length; i++)
+            {
+                var token = tokens[i];
+
+                if (token.Kind == TokenKind.Placeholder)
+                {
+                    if (token.IsNegated)
+                        throw new InvalidOperationException(
+                            $"Negated placeholder '[{PlaceholderNegationMarker}{token.Name}]' in '{Value}' cannot be substituted; use bound matching instead.");
+
+                    if (!capturedValues.TryGetValue(token.Name, out var capturedValue))
+                        throw new InvalidOperationException($"No captured value for placeholder '{token.Name}' in '{Value}'.");
+
+                    resultComponents[i] = capturedValue;
+                }
+                else
+                {
+                    resultComponents[i] = token.Text;
+                }
+            }
+
+            return string.Join(DomainPartSeparator.ToString(), resultComponents);
+        }
+
+        /// <summary>
+        /// Returns a boolean value indicating if the given <paramref name="domainAsString"/> is a valid <see cref="PlaceholderDomain"/>.
+        /// </summary>
+        /// <param name="domainAsString">The domain string to check.</param>
+        /// <returns>True, if and only if the <paramref name="domainAsString"/> is valid.</returns>
+        public static bool IsValid(string domainAsString)
+        {
+            var parts = domainAsString.Split(DomainPartSeparator);
+
+            var anyPlaceholder = false;
+
+            foreach (var part in parts)
+            {
+                if (string.IsNullOrWhiteSpace(part))
+                    return false;
+
+                if (TryParsePlaceholderToken(part, out _, out _, out _))
+                {
+                    anyPlaceholder = true;
+                    continue;
+                }
+
+                if (part is WildcardDomain.SingleDomainMarker or WildcardDomain.AnyDomainMarker)
+                    continue;
+
+                // A literal component must not contain wildcard or placeholder characters.
+                if (part.IndexOfAny(new[]
+                    {
+                        WildcardDomain.SingleDomainMarker[0],
+                        WildcardDomain.AnyDomainMarker[0],
+                        PlaceholderStartMarker[0],
+                        PlaceholderEndMarker[0]
+                    }) >= 0)
+                    return false;
+            }
+
+            if (!anyPlaceholder)
+                return false;
+
+            // Adjacent multi-matching tokens ('*' or '[Name*]') are rejected,
+            // mirroring the WildcardDomain rule that forbids '*.*' (avoids ambiguous captures).
+            for (var i = 0; i < parts.Length - 1; i++)
+            {
+                if (IsMultiMatchingToken(parts[i]) && IsMultiMatchingToken(parts[i + 1]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static bool IsMultiMatchingToken(string component)
+        {
+            return component == WildcardDomain.AnyDomainMarker ||
+                   (TryParsePlaceholderToken(component, out _, out var isMulti, out _) && isMulti);
+        }
+
+        private static bool TryParsePlaceholderToken(string component, out string name, out bool isMulti, out bool isNegated)
+        {
+            var match = PlaceholderTokenRegex.Match(component);
+
+            // A negated multi placeholder ('[!Name*]') is not a valid token: the ambiguous split of a
+            // multi-component "not equal" comparison has no deterministic semantics.
+            if (!match.Success || (match.Groups["negated"].Success && match.Groups["multi"].Success))
+            {
+                name = null;
+                isMulti = false;
+                isNegated = false;
+                return false;
+            }
+
+            name = match.Groups["name"].Value;
+            isMulti = match.Groups["multi"].Success;
+            isNegated = match.Groups["negated"].Success;
+            return true;
+        }
+
+        /// <summary>
+        /// Backtracking matcher over domain components, modeled after <see cref="WildcardDomain"/>'s
+        /// distance calculation, extended with capture recording (capture mode, <paramref name="boundValues"/> is null)
+        /// or comparison against previously captured values (bound mode, <paramref name="captures"/> is null).
+        /// The pattern is pre-tokenized, so the match path performs string comparisons only.
+        /// </summary>
+        private static bool TryMatchRecursive(
+            ReadOnlySpan<string> remainingActual,
+            ReadOnlySpan<Token> remainingPattern,
+            Dictionary<string, string> captures,
+            IReadOnlyDictionary<string, string> boundValues)
+        {
+            if (remainingPattern.IsEmpty)
+                return remainingActual.IsEmpty;
+
+            var token = remainingPattern[0];
+
+            switch (token.Kind)
+            {
+                case TokenKind.SingleWildcard:
+                    return !remainingActual.IsEmpty &&
+                           TryMatchRecursive(remainingActual.Slice(1), remainingPattern.Slice(1), captures, boundValues);
+
+                case TokenKind.AnyWildcard:
+                    // Option 1: the '*' matches zero components.
+                    if (TryMatchRecursive(remainingActual, remainingPattern.Slice(1), captures, boundValues))
+                        return true;
+
+                    // Option 2: the '*' consumes one more component.
+                    return !remainingActual.IsEmpty &&
+                           TryMatchRecursive(remainingActual.Slice(1), remainingPattern, captures, boundValues);
+
+                case TokenKind.Placeholder:
+                    return boundValues != null
+                        ? TryMatchBoundPlaceholder(remainingActual, remainingPattern, token, boundValues)
+                        : TryMatchCapturingPlaceholder(remainingActual, remainingPattern, token, captures);
+
+                default:
+                    return !remainingActual.IsEmpty &&
+                           token.Text == remainingActual[0] &&
+                           TryMatchRecursive(remainingActual.Slice(1), remainingPattern.Slice(1), captures, boundValues);
+            }
+        }
+
+        private static bool TryMatchCapturingPlaceholder(
+            ReadOnlySpan<string> remainingActual,
+            ReadOnlySpan<Token> remainingPattern,
+            Token token,
+            Dictionary<string, string> captures)
+        {
+            // Negated placeholders have no capture semantics
+            // (rejected on the 'From' side by DependencyRule anyway).
+            if (token.IsNegated || remainingActual.IsEmpty)
+                return false;
+
+            var maxLength = token.IsMulti ? remainingActual.Length : 1;
+
+            // Shortest-first: deterministic capture semantics.
+            for (var length = 1; length <= maxLength; length++)
+            {
+                var candidate = length == 1
+                    ? remainingActual[0]
+                    : string.Join(DomainPartSeparator.ToString(), remainingActual.Slice(0, length).ToArray());
+
+                captures[token.Name] = candidate;
+
+                if (TryMatchRecursive(remainingActual.Slice(length), remainingPattern.Slice(1), captures, boundValues: null))
+                    return true;
+
+                // Backtrack.
+                captures.Remove(token.Name);
+            }
+
+            return false;
+        }
+
+        private static bool TryMatchBoundPlaceholder(
+            ReadOnlySpan<string> remainingActual,
+            ReadOnlySpan<Token> remainingPattern,
+            Token token,
+            IReadOnlyDictionary<string, string> boundValues)
+        {
+            if (!boundValues.TryGetValue(token.Name, out var boundValue))
+                return false;
+
+            if (token.IsNegated)
+            {
+                // '[!Name]' consumes exactly one component that must differ from the bound value.
+                return !remainingActual.IsEmpty &&
+                       remainingActual[0] != boundValue &&
+                       TryMatchRecursive(remainingActual.Slice(1), remainingPattern.Slice(1), captures: null, boundValues);
+            }
+
+            // '[Name]' consumes exactly the bound value, which may span several
+            // components if it was captured by a multi placeholder ('[Name*]').
+            var boundComponents = boundValue.Split(DomainPartSeparator);
+
+            if (remainingActual.Length < boundComponents.Length)
+                return false;
+
+            for (var i = 0; i < boundComponents.Length; i++)
+            {
+                if (remainingActual[i] != boundComponents[i])
+                    return false;
+            }
+
+            return TryMatchRecursive(remainingActual.Slice(boundComponents.Length), remainingPattern.Slice(1), captures: null, boundValues);
+        }
+
+        private WildcardDomain GetDegradedWildcardDomain()
+        {
+            return _degradedWildcardDomain ??= CreateDegradedWildcardDomain();
+        }
+
+        private WildcardDomain CreateDegradedWildcardDomain()
+        {
+            var degradedComponents = GetTokens()
+                .Select(token => token.Kind == TokenKind.Placeholder
+                    ? (token.IsMulti ? WildcardDomain.AnyDomainMarker : WildcardDomain.SingleDomainMarker)
+                    : token.Text);
+
+            var degradedString = string.Join(DomainPartSeparator.ToString(), degradedComponents);
+
+            // The degraded form is valid by construction (contains at least one wildcard,
+            // adjacent multi tokens are rejected in IsValid), so validation is skipped.
+            return new WildcardDomain(degradedString, validate: false);
+        }
+    }
+}

--- a/source/NsDepCop.Analyzer/Config/PlaceholderDomain.cs
+++ b/source/NsDepCop.Analyzer/Config/PlaceholderDomain.cs
@@ -166,6 +166,15 @@ namespace Codartis.NsDepCop.Config
             return GetDegradedWildcardDomain().GetMatchRelevance(domain);
         }
 
+        /// <inheritdoc />
+        /// <remarks>
+        /// Every placeholder is substituted with a fixed captured value on the 'To' side, so the
+        /// specification pins down a single concrete domain per match, unless it also contains
+        /// '?'/'*' wildcards (which can still match more than one domain).
+        /// </remarks>
+        public override bool ResolvesToSingleDomainPerMatch =>
+            GetTokens().All(token => token.Kind != TokenKind.SingleWildcard && token.Kind != TokenKind.AnyWildcard);
+
         /// <summary>
         /// Matches this specification against a concrete domain and extracts the placeholder captures.
         /// </summary>

--- a/source/NsDepCop.Analyzer/Config/WildcardDomain.cs
+++ b/source/NsDepCop.Analyzer/Config/WildcardDomain.cs
@@ -34,7 +34,7 @@ namespace Codartis.NsDepCop.Config
         /// <inheritdoc />
         public override int GetMatchRelevance(Domain domain)
         {
-            var actualList = domain.ToString().Split(DomainPartSeparator);
+            var actualList = domain.ToComponents();
 
             var distance = CalcDistance(actualList, _domainComponents, 0);
 

--- a/source/NsDepCop.Benchmarks/NsDepCop.Benchmarks.RuleTypesBenchmarks-report-github.md
+++ b/source/NsDepCop.Benchmarks/NsDepCop.Benchmarks.RuleTypesBenchmarks-report-github.md
@@ -1,20 +1,18 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.5608/22H2/2022Update)
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26200.8875)
 Intel Core i7-10850H CPU 2.70GHz, 1 CPU, 12 logical and 6 physical cores
-.NET SDK 9.0.201
-  [Host]     : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2
-  DefaultJob : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2
+.NET SDK 10.0.302
+  [Host]     : .NET 8.0.29 (8.0.2926.32403), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.29 (8.0.2926.32403), X64 RyuJIT AVX2
 
 
 ```
-| Method             | Iterations | regexCompilationMode | useStaticRegexCache | Mean           | Error        | StdDev      | Gen0      | Gen1      | Allocated |
-|------------------- |----------- |--------------------- |-------------------- |---------------:|-------------:|------------:|----------:|----------:|----------:|
-| SimpleRule         | 1000       | ?                    | ?                   |       274.7 μs |      2.82 μs |     2.50 μs |  187.5000 |    0.4883 |   1.12 MB |
-| WildcardRule       | 1000       | ?                    | ?                   |       493.7 μs |      3.13 μs |     2.93 μs |  259.7656 |    0.9766 |   1.56 MB |
-| RegexRule_Instance | 1000       | Interpreted          | ?                   |       507.8 μs |      4.79 μs |     4.24 μs |  187.5000 |         - |   1.13 MB |
-| RegexRule_Static   | 1000       | Compiled             | True                |       536.1 μs |     10.63 μs |     9.94 μs |  221.6797 |         - |   1.33 MB |
-| RegexRule_Static   | 1000       | Interpreted          | True                |       642.8 μs |      6.56 μs |     6.13 μs |  221.6797 |         - |   1.33 MB |
-| RegexRule_Instance | 1000       | Compiled             | ?                   |     1,065.3 μs |      3.66 μs |     3.24 μs |  189.4531 |   19.5313 |   1.13 MB |
-| RegexRule_Static   | 1000       | Interpreted          | False               |     2,859.5 μs |     28.90 μs |    24.13 μs | 1312.5000 |         - |   7.94 MB |
-| RegexRule_Static   | 1000       | Compiled             | False               | 1,948,017.4 μs | 10,476.50 μs | 8,748.35 μs | 4000.0000 | 3000.0000 |  29.51 MB |
+| Method                       | Iterations | Mean     | Error   | StdDev  | Gen0     | Gen1   | Allocated |
+|----------------------------- |----------- |---------:|--------:|--------:|---------:|-------:|----------:|
+| SimpleRule                   | 1000       | 313.8 μs | 6.00 μs | 5.62 μs | 187.5000 | 0.4883 |   1.12 MB |
+| RegexRule                    | 1000       | 536.0 μs | 6.74 μs | 6.30 μs | 187.5000 |      - |   1.13 MB |
+| WildcardRule                 | 1000       | 566.1 μs | 6.00 μs | 5.32 μs | 259.7656 | 0.9766 |   1.56 MB |
+| PlaceholderRule_Negated      | 1000       | 617.5 μs | 7.73 μs | 6.85 μs | 297.8516 | 1.9531 |   1.78 MB |
+| PlaceholderRule              | 1000       | 623.7 μs | 8.71 μs | 8.94 μs | 292.9688 | 2.9297 |   1.76 MB |
+| PlaceholderRule_MultiCapture | 1000       | 731.3 μs | 6.97 μs | 6.52 μs | 319.3359 | 3.9063 |   1.92 MB |

--- a/source/NsDepCop.Benchmarks/Program.cs
+++ b/source/NsDepCop.Benchmarks/Program.cs
@@ -6,6 +6,8 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        BenchmarkRunner.Run<RuleTypesBenchmarks>();
+        // Pass CLI args through so runs can be filtered/configured, eg.
+        //   dotnet run -c Release -- --filter *PlaceholderRule* --job short
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
     }
 }

--- a/source/NsDepCop.Benchmarks/RuleTypesBenchmarks.cs
+++ b/source/NsDepCop.Benchmarks/RuleTypesBenchmarks.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.RegularExpressions;
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
 using Codartis.NsDepCop.Analysis;
 using Codartis.NsDepCop.Analysis.Implementation;
@@ -31,52 +30,48 @@ public class RuleTypesBenchmarks
     }
 
     /// <summary>
-    /// Benchmark using a Regex object instance, with or without RegexOptions.Compiled.
+    /// Benchmark matching how a RegexDomain is created in production (see DomainSpecificationParser):
+    /// a Regex instance (not the static Regex cache), interpreted (not compiled).
     /// </summary>
     [Benchmark]
-    [Arguments(RegexCompilationMode.Compiled)]
-    [Arguments(RegexCompilationMode.Interpreted)]
-    public void RegexRule_Instance(RegexCompilationMode regexCompilationMode)
+    public void RegexRule()
     {
-        var regexDomain = new RegexDomain("/[A-Z.]*/", validate: true, RegexUsageMode.Instance, regexCompilationMode);
+        var regexDomain = new RegexDomain("/[A-Z.]*/", validate: true, RegexUsageMode.Instance, RegexCompilationMode.Interpreted);
         var config = new DependencyRulesBuilder().AddAllowed(regexDomain, regexDomain);
         BenchmarkCore(config, Iterations);
     }
 
-    /// <summary>
-    /// Benchmark using the static Regex.IsMatch method, with or without RegexOptions.Compiled,
-    /// and with or without using the built-in cache for static Regex.IsMatch calls.
-    /// The reason behind measuring performance also with the static Regex cache turned off,
-    /// is that in real-world usage there probably will be more than 15 different patterns,
-    /// so the cache won't be effective anyway.
-    /// </summary>
-    /// <remarks>
-    /// See: https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-regex
-    /// By default, the last 15 most recently used static regular expression patterns are cached.
-    /// For applications that require a larger number of cached static regular expressions,
-    /// the size of the cache can be adjusted by setting the Regex.CacheSize property.
-    /// </remarks>
     [Benchmark]
-    [Arguments(RegexCompilationMode.Compiled, true)]
-    [Arguments(RegexCompilationMode.Compiled, false)]
-    [Arguments(RegexCompilationMode.Interpreted, true)]
-    [Arguments(RegexCompilationMode.Interpreted, false)]
-    public void RegexRule_Static(RegexCompilationMode regexCompilationMode, bool useStaticRegexCache)
+    public void PlaceholderRule()
     {
-        Regex.CacheSize = useStaticRegexCache ? 15 : 0;
+        var config = new DependencyRulesBuilder().AddAllowed(new PlaceholderDomain("[M].Services"), new PlaceholderDomain("[M].Domain"));
+        BenchmarkCore(config, Iterations, "A.Services", "A.Domain");
+    }
 
-        var regexDomain = new RegexDomain("/[A-Z.]*/", validate: true, RegexUsageMode.Static, regexCompilationMode);
-        var config = new DependencyRulesBuilder().AddAllowed(regexDomain, regexDomain);
-        BenchmarkCore(config, Iterations);
+    [Benchmark]
+    public void PlaceholderRule_MultiCapture()
+    {
+        var config = new DependencyRulesBuilder().AddAllowed(new PlaceholderDomain("[M*].Services"), new PlaceholderDomain("[M*].Domain"));
+        BenchmarkCore(config, Iterations, "A.B.Services", "A.B.Domain");
+    }
+
+    [Benchmark]
+    public void PlaceholderRule_Negated()
+    {
+        var config = new DependencyRulesBuilder().AddAllowed(new PlaceholderDomain("[M].Services"), new PlaceholderDomain("[!M].Domain"));
+        BenchmarkCore(config, Iterations, "A.Services", "B.Domain");
     }
 
     private static void BenchmarkCore(IDependencyRules config, int iterations)
+        => BenchmarkCore(config, iterations, "A.B.C", "D.E.F");
+
+    private static void BenchmarkCore(IDependencyRules config, int iterations, string fromNamespace, string toNamespace)
     {
         var typeDependencyValidator = new TypeDependencyValidator(config);
 
         for (var i = 0; i < iterations; i++)
         {
-            var dependencyStatus = typeDependencyValidator.IsAllowedDependency(new TypeDependency("A.B.C", "T", "D.E.F", "T", default));
+            var dependencyStatus = typeDependencyValidator.IsAllowedDependency(new TypeDependency(fromNamespace, "T", toNamespace, "T", default));
             dependencyStatus.IsAllowed.Should().BeTrue();
         }
     }

--- a/source/NsDepCop.Test/Implementation/Analysis/TypeDependencyValidatorPlaceholderTests.cs
+++ b/source/NsDepCop.Test/Implementation/Analysis/TypeDependencyValidatorPlaceholderTests.cs
@@ -1,0 +1,106 @@
+﻿using Codartis.NsDepCop.Analysis.Implementation;
+using FluentAssertions;
+using Xunit;
+
+namespace Codartis.NsDepCop.Test.Implementation.Analysis
+{
+    public class TypeDependencyValidatorPlaceholderTests
+    {
+        [Fact]
+        public void AllowRule_WithPlaceholder_AllowsOnlyWithinTheSameModule()
+        {
+            var ruleConfig = new DependencyRulesBuilder()
+                .AddAllowed("MyApp.[Module].Domain", "MyApp.[Module].Contracts");
+
+            var dependencyValidator = new TypeDependencyValidator(ruleConfig);
+
+            dependencyValidator.IsAllowedDependency("MyApp.A.Domain", "C1", "MyApp.A.Contracts", "C2").Should().BeTrue();
+            dependencyValidator.IsAllowedDependency("MyApp.B.Domain", "C1", "MyApp.B.Contracts", "C2").Should().BeTrue();
+
+            // The capture links both sides: cross-module access is disallowed.
+            dependencyValidator.IsAllowedDependency("MyApp.A.Domain", "C1", "MyApp.B.Contracts", "C2").Should().BeFalse();
+            dependencyValidator.IsAllowedDependency("MyApp.B.Domain", "C1", "MyApp.A.Contracts", "C2").Should().BeFalse();
+        }
+
+        [Fact]
+        public void AllowRule_WithPlaceholderAndTrailingWildcard_AllowsModuleSubtree()
+        {
+            var ruleConfig = new DependencyRulesBuilder()
+                .AddAllowed("MyApp.[Module].Application.*", "MyApp.[Module].Contracts.*");
+
+            var dependencyValidator = new TypeDependencyValidator(ruleConfig);
+
+            dependencyValidator.IsAllowedDependency("MyApp.A.Application", "C1", "MyApp.A.Contracts.Events", "C2").Should().BeTrue();
+            dependencyValidator.IsAllowedDependency("MyApp.A.Application.Handlers", "C1", "MyApp.A.Contracts", "C2").Should().BeTrue();
+            dependencyValidator.IsAllowedDependency("MyApp.A.Application", "C1", "MyApp.B.Contracts.Events", "C2").Should().BeFalse();
+        }
+
+        [Fact]
+        public void DisallowRule_WithPlaceholder_TrumpsBroadAllowRule()
+        {
+            var ruleConfig = new DependencyRulesBuilder()
+                .AddAllowed("*", "*")
+                .AddDisallowed("MyApp.[Module].Domain", "MyApp.[Module].Infrastructure");
+
+            var dependencyValidator = new TypeDependencyValidator(ruleConfig);
+
+            // Same module: the placeholder disallow rule fires.
+            dependencyValidator.IsAllowedDependency("MyApp.A.Domain", "C1", "MyApp.A.Infrastructure", "C2").Should().BeFalse();
+
+            // Cross module: the disallow rule does not fire, the broad allow rule applies.
+            dependencyValidator.IsAllowedDependency("MyApp.A.Domain", "C1", "MyApp.B.Infrastructure", "C2").Should().BeTrue();
+        }
+
+        [Fact]
+        public void AllowRule_WithVisibleMembers_WorksForPlaceholderRules()
+        {
+            var ruleConfig = new DependencyRulesBuilder()
+                .AddAllowed("MyApp.[Module].Application", "MyApp.[Module].Contracts", "VisibleType");
+
+            var dependencyValidator = new TypeDependencyValidator(ruleConfig);
+
+            dependencyValidator.IsAllowedDependency("MyApp.A.Application", "C1", "MyApp.A.Contracts", "VisibleType").Should().BeTrue();
+            dependencyValidator.IsAllowedDependency("MyApp.A.Application", "C1", "MyApp.A.Contracts", "HiddenType").Should().BeFalse();
+        }
+
+        [Fact]
+        public void DisallowRule_WithNegatedPlaceholder_BlocksForeignSharedDespiteBroadAllow()
+        {
+            // The requirement: features may use their own Shared and parent-level Shared,
+            // but never the Shared of a foreign feature - robust even against a broad allow
+            // rule (eg. inherited from a parent-level config).
+            var ruleConfig = new DependencyRulesBuilder()
+                .AddAllowed("Features.*", "Features.*")
+                .AddDisallowed("Features.[F].*", "Features.[!F].Shared.*");
+
+            var dependencyValidator = new TypeDependencyValidator(ruleConfig);
+
+            // Own Shared: the negated disallow rule does not fire, the broad allow applies.
+            dependencyValidator.IsAllowedDependency("Features.A.Domain", "C1", "Features.A.Shared", "C2").Should().BeTrue();
+            dependencyValidator.IsAllowedDependency("Features.A.Domain", "C1", "Features.A.Shared.Events", "C2").Should().BeTrue();
+
+            // Foreign Shared: blocked, no matter what allow rules exist.
+            dependencyValidator.IsAllowedDependency("Features.A.Domain", "C1", "Features.B.Shared", "C2").Should().BeFalse();
+            dependencyValidator.IsAllowedDependency("Features.A.Domain", "C1", "Features.B.Shared.Events", "C2").Should().BeFalse();
+
+            // Foreign non-Shared namespaces are unaffected by the disallow rule.
+            dependencyValidator.IsAllowedDependency("Features.A.Domain", "C1", "Features.B.Contracts", "C2").Should().BeTrue();
+        }
+
+        [Fact]
+        public void MostSpecificRuleSelection_TreatsPlaceholderLikeSingleWildcard()
+        {
+            // Both rules match 'MyApp.A.Domain' -> 'MyApp.A.Contracts'.
+            // The placeholder rule ('MyApp.?.Domain' equivalent) is more specific than 'MyApp.*'
+            // and restricts visible members; the broader rule must not win.
+            var ruleConfig = new DependencyRulesBuilder()
+                .AddAllowed("MyApp.[Module].Domain", "MyApp.[Module].Contracts", "VisibleType")
+                .AddAllowed("MyApp.*", "MyApp.*");
+
+            var dependencyValidator = new TypeDependencyValidator(ruleConfig);
+
+            dependencyValidator.IsAllowedDependency("MyApp.A.Domain", "C1", "MyApp.A.Contracts", "VisibleType").Should().BeTrue();
+            dependencyValidator.IsAllowedDependency("MyApp.A.Domain", "C1", "MyApp.A.Contracts", "HiddenType").Should().BeFalse();
+        }
+    }
+}

--- a/source/NsDepCop.Test/Implementation/Config/XmlConfigParserTests.cs
+++ b/source/NsDepCop.Test/Implementation/Config/XmlConfigParserTests.cs
@@ -126,7 +126,31 @@ namespace Codartis.NsDepCop.Test.Implementation.Config
         {
             var xDocument = LoadXml("AllowedRuleForWildcardNamespaceWithVisibleMembers.nsdepcop");
             Action a = () => XmlConfigParser.Parse(xDocument);
-            a.Should().Throw<Exception>().WithMessage("*must be a single namespace*");
+            a.Should().Throw<Exception>().WithMessage("*must resolve to a single namespace*");
+        }
+
+        [Fact]
+        public void Parse_AllowedRuleForPlaceholderNamespaceWithVisibleMembers_Works()
+        {
+            // A placeholder 'To' side (with no '?'/'*' wildcards) resolves to a single concrete
+            // namespace per match, so it can carry an inline VisibleMembers surface.
+            var xDocument = LoadXml("AllowedRuleForPlaceholderNamespaceWithVisibleMembers.nsdepcop");
+            var config = XmlConfigParser.Parse(xDocument);
+
+            var types = config.AllowRules[new DependencyRule("MyApp.[Module].Application", "MyApp.[Module].Contracts")];
+            types.Should().HaveCount(2);
+            types.Should().Contain("T1");
+            types.Should().Contain("T2");
+        }
+
+        [Fact]
+        public void Parse_AllowedRuleForPlaceholderWithWildcardNamespaceWithVisibleMembers_Throws()
+        {
+            // The substituted 'To' side still contains a '*', so it matches more than one namespace
+            // and the VisibleMembers surface would be ambiguous.
+            var xDocument = LoadXml("AllowedRuleForPlaceholderWithWildcardNamespaceWithVisibleMembers.nsdepcop");
+            Action a = () => XmlConfigParser.Parse(xDocument);
+            a.Should().Throw<Exception>().WithMessage("*must resolve to a single namespace*");
         }
 
         [Fact]

--- a/source/NsDepCop.Test/Implementation/Config/XmlConfigParserTests/AllowedRuleForPlaceholderNamespaceWithVisibleMembers.nsdepcop
+++ b/source/NsDepCop.Test/Implementation/Config/XmlConfigParserTests/AllowedRuleForPlaceholderNamespaceWithVisibleMembers.nsdepcop
@@ -1,0 +1,8 @@
+<NsDepCopConfig>
+    <Allowed From="MyApp.[Module].Application" To="MyApp.[Module].Contracts">
+        <VisibleMembers>
+            <Type Name="T1"/>
+            <Type Name="T2"/>
+        </VisibleMembers>
+    </Allowed>
+</NsDepCopConfig>

--- a/source/NsDepCop.Test/Implementation/Config/XmlConfigParserTests/AllowedRuleForPlaceholderWithWildcardNamespaceWithVisibleMembers.nsdepcop
+++ b/source/NsDepCop.Test/Implementation/Config/XmlConfigParserTests/AllowedRuleForPlaceholderWithWildcardNamespaceWithVisibleMembers.nsdepcop
@@ -1,0 +1,7 @@
+<NsDepCopConfig>
+    <Allowed From="MyApp.[Module].Application" To="MyApp.[Module].Contracts.*">
+        <VisibleMembers>
+            <Type Name="T1"/>
+        </VisibleMembers>
+    </Allowed>
+</NsDepCopConfig>

--- a/source/NsDepCop.Test/Interface/Config/DependencyRulePlaceholderTests.cs
+++ b/source/NsDepCop.Test/Interface/Config/DependencyRulePlaceholderTests.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using Codartis.NsDepCop.Config;
+using FluentAssertions;
+using Xunit;
+
+namespace Codartis.NsDepCop.Test.Interface.Config
+{
+    public class DependencyRulePlaceholderTests
+    {
+        [Fact]
+        public void Matches_WithoutPlaceholders_BehavesLikeIndependentSideMatching()
+        {
+            var rule = new DependencyRule("S.*", "T.*");
+
+            rule.Matches(new Domain("S.A"), new Domain("T.B")).Should().BeTrue();
+            rule.Matches(new Domain("S.A"), new Domain("X")).Should().BeFalse();
+            rule.Matches(new Domain("X"), new Domain("T.B")).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Matches_TransfersCaptureFromFromSideToToSide()
+        {
+            var rule = new DependencyRule("MyApp.[Module].Domain", "MyApp.[Module].Contracts");
+
+            // Same module: allowed.
+            rule.Matches(new Domain("MyApp.A.Domain"), new Domain("MyApp.A.Contracts")).Should().BeTrue();
+            rule.Matches(new Domain("MyApp.B.Domain"), new Domain("MyApp.B.Contracts")).Should().BeTrue();
+
+            // Cross module: the capture does not match the target.
+            rule.Matches(new Domain("MyApp.A.Domain"), new Domain("MyApp.B.Contracts")).Should().BeFalse();
+
+            // 'From' side does not match at all.
+            rule.Matches(new Domain("Other.A.Domain"), new Domain("MyApp.A.Contracts")).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Matches_SubstitutedToSide_MayStillContainWildcards()
+        {
+            var rule = new DependencyRule("MyApp.[Module].Domain", "MyApp.[Module].Contracts.*");
+
+            rule.Matches(new Domain("MyApp.A.Domain"), new Domain("MyApp.A.Contracts")).Should().BeTrue();
+            rule.Matches(new Domain("MyApp.A.Domain"), new Domain("MyApp.A.Contracts.Events")).Should().BeTrue();
+            rule.Matches(new Domain("MyApp.A.Domain"), new Domain("MyApp.B.Contracts.Events")).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Matches_MultiComponentPlaceholder_TransfersWholeSubPath()
+        {
+            var rule = new DependencyRule("App.[Path*].Domain", "App.[Path*].Contracts");
+
+            rule.Matches(new Domain("App.A.B.Domain"), new Domain("App.A.B.Contracts")).Should().BeTrue();
+            rule.Matches(new Domain("App.A.B.Domain"), new Domain("App.A.Contracts")).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Matches_PlaceholderOnFromSideOnly_MatchesToSideIndependently()
+        {
+            var rule = new DependencyRule("MyApp.[Module].Domain", "MyApp.Common");
+
+            rule.Matches(new Domain("MyApp.A.Domain"), new Domain("MyApp.Common")).Should().BeTrue();
+            rule.Matches(new Domain("MyApp.A.Domain"), new Domain("MyApp.Other")).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Matches_PlaceholdersAreBoundByName_NotByPosition()
+        {
+            var rule = new DependencyRule("App.[P1].[P2].*", "App.[P2].[P1].*");
+
+            rule.Matches(new Domain("App.X.Y.Domain"), new Domain("App.Y.X.Contracts")).Should().BeTrue();
+            rule.Matches(new Domain("App.X.Y.Domain"), new Domain("App.X.Y.Contracts")).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Matches_SameCaptureUsedTwiceOnToSide_Works()
+        {
+            var rule = new DependencyRule("A.[M].B", "X.[M].Y.[M]");
+
+            rule.Matches(new Domain("A.Foo.B"), new Domain("X.Foo.Y.Foo")).Should().BeTrue();
+            rule.Matches(new Domain("A.Foo.B"), new Domain("X.Foo.Y.Bar")).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Create_UnboundPlaceholderOnToSide_ThrowsFormatException()
+        {
+            Assert.Throws<FormatException>(() => new DependencyRule("MyApp.[Module].Domain", "MyApp.[Other].Contracts"));
+        }
+
+        [Fact]
+        public void Create_ToSidePlaceholderWithoutPlaceholderFromSide_ThrowsFormatException()
+        {
+            Assert.Throws<FormatException>(() => new DependencyRule("MyApp.*", "MyApp.[Module].Contracts"));
+        }
+
+        [Fact]
+        public void Create_DuplicatePlaceholderNamesOnFromSide_ThrowsFormatException()
+        {
+            Assert.Throws<FormatException>(() => new DependencyRule("MyApp.[M].[M]", "MyApp.[M]"));
+        }
+
+        [Fact]
+        public void Matches_NegatedPlaceholder_ExpressesInequality()
+        {
+            var rule = new DependencyRule("Features.[F].*", "Features.[!F].Shared.*");
+
+            // F != G: the rule fires.
+            rule.Matches(new Domain("Features.A.Domain"), new Domain("Features.B.Shared.Events")).Should().BeTrue();
+
+            // F == G: the rule does not fire.
+            rule.Matches(new Domain("Features.A.Domain"), new Domain("Features.A.Shared.Events")).Should().BeFalse();
+
+            // Different 'To' shape: the rule does not fire.
+            rule.Matches(new Domain("Features.A.Domain"), new Domain("Features.Shared.Events")).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Matches_NegatedAndPositiveReference_Combined()
+        {
+            var rule = new DependencyRule("App.[F].[Layer].*", "App.[!F].[Layer].*");
+
+            // Other feature, same layer: fires.
+            rule.Matches(new Domain("App.A.Domain"), new Domain("App.B.Domain")).Should().BeTrue();
+
+            // Other feature, other layer: does not fire.
+            rule.Matches(new Domain("App.A.Domain"), new Domain("App.B.Infrastructure")).Should().BeFalse();
+
+            // Same feature: does not fire.
+            rule.Matches(new Domain("App.A.Domain"), new Domain("App.A.Domain")).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Create_NegatedPlaceholderOnFromSide_ThrowsFormatException()
+        {
+            Assert.Throws<FormatException>(() => new DependencyRule("Features.[!F].*", "Features.Shared.*"));
+        }
+
+        [Fact]
+        public void Create_UnboundNegatedPlaceholder_ThrowsFormatException()
+        {
+            Assert.Throws<FormatException>(() => new DependencyRule("Features.[F].*", "Features.[!G].Shared.*"));
+        }
+
+        [Fact]
+        public void Create_NegatedReferenceToMultiPlaceholder_ThrowsFormatException()
+        {
+            Assert.Throws<FormatException>(() => new DependencyRule("Features.[F*].X", "Features.[!F].Shared.*"));
+        }
+
+        [Fact]
+        public void GetFromMatchRelevance_PlaceholderRule_EqualsDegradedWildcardRelevance()
+        {
+            var rule = new DependencyRule("MyApp.[Module].Domain", "MyApp.[Module].Contracts");
+            var from = new Domain("MyApp.A.Domain");
+
+            rule.GetFromMatchRelevance(from)
+                .Should().Be(new WildcardDomain("MyApp.?.Domain").GetMatchRelevance(from));
+        }
+
+        [Fact]
+        public void EqualsAndHashCode_WorkAsDictionaryKey_ForPlaceholderRules()
+        {
+            var rule1 = new DependencyRule("MyApp.[M].Domain", "MyApp.[M].Contracts");
+            var rule2 = new DependencyRule("MyApp.[M].Domain", "MyApp.[M].Contracts");
+            var rule3 = new DependencyRule("MyApp.[M].Domain", "MyApp.[M].Application");
+
+            rule1.Equals(rule2).Should().BeTrue();
+            rule1.GetHashCode().Should().Be(rule2.GetHashCode());
+            rule1.Equals(rule3).Should().BeFalse();
+        }
+    }
+}

--- a/source/NsDepCop.Test/Interface/Config/DependencyRulePlaceholderTests.cs
+++ b/source/NsDepCop.Test/Interface/Config/DependencyRulePlaceholderTests.cs
@@ -62,6 +62,26 @@ namespace Codartis.NsDepCop.Test.Interface.Config
         }
 
         [Fact]
+        public void Matches_FromOnlyMultiPlaceholder_StillRequiresAtLeastOneComponent()
+        {
+            // '[Name*]' means "one or more components" everywhere, even when the placeholder appears
+            // only on the 'From' side (the 'To' side has no placeholder to link to). It must not
+            // degrade to a plain '*' that also matches zero components.
+            var rule = new DependencyRule("MyApp.[M*].Services", "MyApp.Common");
+
+            rule.Matches(new Domain("MyApp.X.Services"), new Domain("MyApp.Common")).Should().BeTrue();
+            rule.Matches(new Domain("MyApp.X.Y.Services"), new Domain("MyApp.Common")).Should().BeTrue();
+
+            // Nothing between 'MyApp' and 'Services': '[M*]' requires at least one component.
+            rule.Matches(new Domain("MyApp.Services"), new Domain("MyApp.Common")).Should().BeFalse();
+
+            // The verdict must not depend on whether the 'To' side carries a placeholder: the linked
+            // form already rejects the zero-component case, and the from-only form must agree.
+            var linkedRule = new DependencyRule("MyApp.[M*].Services", "MyApp.[M*].Common");
+            linkedRule.Matches(new Domain("MyApp.Services"), new Domain("MyApp.Common")).Should().BeFalse();
+        }
+
+        [Fact]
         public void Matches_PlaceholdersAreBoundByName_NotByPosition()
         {
             var rule = new DependencyRule("App.[P1].[P2].*", "App.[P2].[P1].*");

--- a/source/NsDepCop.Test/Interface/Config/DependencyRulePlaceholderTests.cs
+++ b/source/NsDepCop.Test/Interface/Config/DependencyRulePlaceholderTests.cs
@@ -100,6 +100,20 @@ namespace Codartis.NsDepCop.Test.Interface.Config
         }
 
         [Fact]
+        public void Matches_GlobalNamespaceOnFromSide_DoesNotMatchAndDoesNotThrow()
+        {
+            // The global namespace ('.') decomposes to zero components, so a placeholder 'From'
+            // side does not match it and nothing is captured - no substitution or parse happens.
+            // The rule simply does not match, without throwing during analysis.
+            var rule = new DependencyRule("[M].[N]", "X.[M]");
+
+            Action act = () => rule.Matches(Domain.GlobalDomain, new Domain("X.Y"));
+
+            act.Should().NotThrow();
+            rule.Matches(Domain.GlobalDomain, new Domain("X.Y")).Should().BeFalse();
+        }
+
+        [Fact]
         public void Create_UnboundPlaceholderOnToSide_ThrowsFormatException()
         {
             Assert.Throws<FormatException>(() => new DependencyRule("MyApp.[Module].Domain", "MyApp.[Other].Contracts"));

--- a/source/NsDepCop.Test/Interface/Config/PlaceholderDomainTests.cs
+++ b/source/NsDepCop.Test/Interface/Config/PlaceholderDomainTests.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Collections.Generic;
+using Codartis.NsDepCop.Config;
+using FluentAssertions;
+using Xunit;
+
+namespace Codartis.NsDepCop.Test.Interface.Config
+{
+    public class PlaceholderDomainTests
+    {
+        [Theory]
+        [InlineData("[M]")]
+        [InlineData("A.[M]")]
+        [InlineData("A.[M].B")]
+        [InlineData("A.[M*].B")]
+        [InlineData("[Module_1].[Module_2]")]
+        [InlineData("A.[M].?.B")]
+        [InlineData("A.[M].*")]
+        [InlineData("*.A.[M]")]
+        [InlineData("A.[M].[M]")]
+        [InlineData("A.[!M].B")]
+        [InlineData("A.[M].[!N]")]
+        public void Create_Works(string placeholderDomainString)
+        {
+            new PlaceholderDomain(placeholderDomainString).ToString().Should().Be(placeholderDomainString);
+        }
+
+        [Fact]
+        public void Create_WithNull_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new PlaceholderDomain(null));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("A")]
+        [InlineData("A.B")]
+        [InlineData("A.*")]
+        [InlineData("A.?.B")]
+        [InlineData("A.[M")]
+        [InlineData("A.M]")]
+        [InlineData("A.[]")]
+        [InlineData("A.[1M]")]
+        [InlineData("A.[M-N]")]
+        [InlineData("A.X[M]")]
+        [InlineData("A.[M]X")]
+        [InlineData("A.[M*].[N*]")]
+        [InlineData("A.*.[M*]")]
+        [InlineData("A.[M*].*")]
+        [InlineData("A..[M]")]
+        [InlineData("A.[!M*]")]
+        [InlineData("A.[!]")]
+        [InlineData("A.[!!M]")]
+        public void Create_Invalid_ThrowsFormatException(string placeholderDomainString)
+        {
+            Assert.Throws<FormatException>(() => new PlaceholderDomain(placeholderDomainString));
+        }
+
+        [Fact]
+        public void PlaceholderNames_ReturnsNamesInOrder_IncludingDuplicates()
+        {
+            new PlaceholderDomain("A.[M].B.[N*].[M]").PlaceholderNames
+                .Should().Equal("M", "N", "M");
+        }
+
+        [Theory]
+        // Single-component placeholder.
+        [InlineData("MyApp.[M].Domain", "MyApp.A.Domain", true, "M", "A")]
+        [InlineData("MyApp.[M].Domain", "MyApp.Domain", false, null, null)]
+        [InlineData("MyApp.[M].Domain", "MyApp.A.B.Domain", false, null, null)]
+        // Multi-component placeholder captures one or more components.
+        [InlineData("MyApp.[M*]", "MyApp.A", true, "M", "A")]
+        [InlineData("MyApp.[M*]", "MyApp.A.B", true, "M", "A.B")]
+        [InlineData("MyApp.[M*]", "MyApp", false, null, null)]
+        [InlineData("[M*].Domain", "MyApp.A.Domain", true, "M", "MyApp.A")]
+        [InlineData("A.[M*].B", "A.P.Q.B", true, "M", "P.Q")]
+        // Mixed with non-capturing wildcards.
+        [InlineData("MyApp.[M].*", "MyApp.X.Y.Z", true, "M", "X")]
+        [InlineData("MyApp.[M].*", "MyApp.X", true, "M", "X")]
+        [InlineData("*.[M].Domain", "A.B.A.Domain", true, "M", "A")]
+        [InlineData("MyApp.[M].?", "MyApp.X.Y", true, "M", "X")]
+        [InlineData("MyApp.[M].?", "MyApp.X", false, null, null)]
+        public void TryMatch_Works(string pattern, string domain, bool expectedResult, string placeholderName, string expectedCapture)
+        {
+            var isMatch = new PlaceholderDomain(pattern).TryMatch(new Domain(domain), out var capturedValues);
+
+            isMatch.Should().Be(expectedResult);
+
+            if (expectedResult)
+                capturedValues[placeholderName].Should().Be(expectedCapture);
+            else
+                capturedValues.Should().BeNull();
+        }
+
+        [Fact]
+        public void TryMatch_MultiplePlaceholders_WithBacktracking()
+        {
+            var isMatch = new PlaceholderDomain("[M].[N*].C").TryMatch(new Domain("A.B1.B2.C"), out var capturedValues);
+
+            isMatch.Should().BeTrue();
+            capturedValues["M"].Should().Be("A");
+            capturedValues["N"].Should().Be("B1.B2");
+        }
+
+        [Fact]
+        public void TryMatch_MultiCapture_IsShortestFirst()
+        {
+            var isMatch = new PlaceholderDomain("A.[M*].?").TryMatch(new Domain("A.P.Q.R"), out var capturedValues);
+
+            isMatch.Should().BeTrue();
+            capturedValues["M"].Should().Be("P.Q");
+        }
+
+        [Theory]
+        [InlineData("MyApp.[M].Contracts", "A", "MyApp.A.Contracts")]
+        [InlineData("MyApp.[M].Contracts.*", "A", "MyApp.A.Contracts.*")]
+        [InlineData("[M].X.[M]", "A.B", "A.B.X.A.B")]
+        public void Substitute_Works(string pattern, string captureValueForM, string expected)
+        {
+            var captures = new Dictionary<string, string> { ["M"] = captureValueForM };
+
+            new PlaceholderDomain(pattern).Substitute(captures).Should().Be(expected);
+        }
+
+        [Fact]
+        public void Substitute_MissingCapture_ThrowsInvalidOperationException()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => new PlaceholderDomain("A.[M]").Substitute(new Dictionary<string, string>()));
+        }
+
+        [Theory]
+        // Positive reference: must equal the bound value.
+        [InlineData("MyApp.[M].Contracts", "MyApp.A.Contracts", "A", true)]
+        [InlineData("MyApp.[M].Contracts", "MyApp.B.Contracts", "A", false)]
+        // Negated reference: must differ from the bound value.
+        [InlineData("MyApp.[!M].Contracts", "MyApp.B.Contracts", "A", true)]
+        [InlineData("MyApp.[!M].Contracts", "MyApp.A.Contracts", "A", false)]
+        // Mixed with wildcards.
+        [InlineData("MyApp.[!M].Shared.*", "MyApp.B.Shared.Events", "A", true)]
+        [InlineData("MyApp.[!M].Shared.*", "MyApp.A.Shared.Events", "A", false)]
+        // Negated reference consumes exactly one component.
+        [InlineData("MyApp.[!M].Contracts", "MyApp.Contracts", "A", false)]
+        public void Matches_WithBoundValues_Works(string pattern, string domain, string boundValueForM, bool expected)
+        {
+            var boundValues = new Dictionary<string, string> { ["M"] = boundValueForM };
+
+            new PlaceholderDomain(pattern).Matches(new Domain(domain), boundValues).Should().Be(expected);
+        }
+
+        [Fact]
+        public void Matches_WithBoundValues_PositiveReferenceToMultiCapture_ConsumesAllComponents()
+        {
+            var boundValues = new Dictionary<string, string> { ["P"] = "A.B" };
+
+            new PlaceholderDomain("X.[P].Y").Matches(new Domain("X.A.B.Y"), boundValues).Should().BeTrue();
+            new PlaceholderDomain("X.[P].Y").Matches(new Domain("X.A.Y"), boundValues).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Substitute_NegatedPlaceholder_ThrowsInvalidOperationException()
+        {
+            var captures = new Dictionary<string, string> { ["M"] = "A" };
+
+            Assert.Throws<InvalidOperationException>(() => new PlaceholderDomain("A.[!M]").Substitute(captures));
+        }
+
+        [Fact]
+        public void GetMatchRelevance_EqualsDegradedWildcardRelevance()
+        {
+            var domain = new Domain("A.X.B");
+
+            new PlaceholderDomain("A.[M].B").GetMatchRelevance(domain)
+                .Should().Be(new WildcardDomain("A.?.B").GetMatchRelevance(domain));
+
+            new PlaceholderDomain("A.[M*]").GetMatchRelevance(domain)
+                .Should().Be(new WildcardDomain("A.*").GetMatchRelevance(domain));
+
+            new PlaceholderDomain("A.[!M].B").GetMatchRelevance(domain)
+                .Should().Be(new WildcardDomain("A.?.B").GetMatchRelevance(domain));
+        }
+
+        [Fact]
+        public void DomainSpecificationParser_RoutesPlaceholderStrings_ToPlaceholderDomain()
+        {
+            DomainSpecificationParser.Parse("A.[M].B").Should().BeOfType<PlaceholderDomain>();
+            DomainSpecificationParser.Parse("A.[M*].B").Should().BeOfType<PlaceholderDomain>();
+        }
+
+        [Fact]
+        public void DomainSpecificationParser_RegexWithCharacterClass_IsNotMisroutedToPlaceholderDomain()
+        {
+            DomainSpecificationParser.Parse(@"/A\.[XY]\.B/").Should().BeOfType<RegexDomain>();
+        }
+    }
+}

--- a/source/NsDepCop.Test/Interface/Config/PlaceholderDomainTests.cs
+++ b/source/NsDepCop.Test/Interface/Config/PlaceholderDomainTests.cs
@@ -111,6 +111,18 @@ namespace Codartis.NsDepCop.Test.Interface.Config
             capturedValues["M"].Should().Be("P.Q");
         }
 
+        [Fact]
+        public void TryMatch_GlobalNamespace_DoesNotMatchPlaceholders()
+        {
+            // The global namespace ('.') has no name components, so a placeholder pattern
+            // (which requires at least one component) must not match or capture it.
+            new PlaceholderDomain("[M].[N]").TryMatch(Domain.GlobalDomain, out var twoPartCaptures).Should().BeFalse();
+            twoPartCaptures.Should().BeNull();
+
+            new PlaceholderDomain("[M*]").TryMatch(Domain.GlobalDomain, out var multiCaptures).Should().BeFalse();
+            multiCaptures.Should().BeNull();
+        }
+
         [Theory]
         [InlineData("MyApp.[M].Contracts", "A", "MyApp.A.Contracts")]
         [InlineData("MyApp.[M].Contracts.*", "A", "MyApp.A.Contracts.*")]

--- a/source/NsDepCop.Test/Interface/Config/WildcardDomainTests.cs
+++ b/source/NsDepCop.Test/Interface/Config/WildcardDomainTests.cs
@@ -50,6 +50,16 @@ namespace Codartis.NsDepCop.Test.Interface.Config
             Assert.Throws<FormatException>(() => new WildcardDomain(wildcardDomainString));
         }
 
+        [Theory]
+        // The global namespace ('.') decomposes to zero components (empty parts are dropped).
+        [InlineData("*", true)]     // '*' matches any number of components, including zero
+        [InlineData("A.*", false)]  // needs a leading 'A' component; the global namespace has none
+        [InlineData("?", false)]    // needs exactly one component
+        public void Matches_GlobalNamespace_TreatedAsZeroComponents(string wildcardDomainString, bool expectedMatch)
+        {
+            new WildcardDomain(wildcardDomainString).Matches(Domain.GlobalDomain).Should().Be(expectedMatch);
+        }
+
         [Fact]
         [SuppressMessage("ReSharper", "EqualExpressionComparison")]
         public void Equals_Works()

--- a/source/NsDepCop.Test/NsDepCop.Test.csproj
+++ b/source/NsDepCop.Test/NsDepCop.Test.csproj
@@ -173,6 +173,12 @@
     <None Include="Implementation\Config\XmlConfigParserTests\AllowedRuleForWildcardNamespaceWithVisibleMembers.nsdepcop">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Implementation\Config\XmlConfigParserTests\AllowedRuleForPlaceholderNamespaceWithVisibleMembers.nsdepcop">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Implementation\Config\XmlConfigParserTests\AllowedRuleForPlaceholderWithWildcardNamespaceWithVisibleMembers.nsdepcop">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Implementation\Config\XmlConfigParserTests\VisibleMembers.nsdepcop">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/source/NsDepCop.sln
+++ b/source/NsDepCop.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.6.11828.311 oobstable
+VisualStudioVersion = 18.6.11828.311
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AB1A4FF5-D372-416A-9986-6C3548F78B3B}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
Closes #89 (see also discussion #86). Semantics and examples are documented in the [Placeholders](doc/Help.md#placeholders) section added by this PR.

## Changes

* New `PlaceholderDomain : DomainSpecification` (naming follows `WildcardDomain`/`RegexDomain`): a backtracking matcher over namespace components, modeled after `WildcardDomain`'s distance calculation, extended with capture recording.
* Pair matching lives in `DependencyRule`: new `Matches(Domain from, Domain to)` and `GetFromMatchRelevance(Domain from)`. For rules without placeholders these are exactly equivalent to the previous `From.Matches(from) && To.Matches(to)`; `TypeDependencyValidator` and `AssemblyDependencyValidator` now call them (3 call sites changed), so placeholders work for namespace and assembly rules alike.
* Positive placeholders: captured values are substituted into the `To` pattern and the result is parsed with the existing `DomainSpecificationParser`, so remaining `?`/`*` wildcards on the `To` side keep working through the existing `WildcardDomain` machinery; substituted specifications are cached per rule. Negated placeholders (`[!Name]`) are compared directly against the captured value.
* Performance: the pattern is tokenized once at construction; the match path performs only string comparisons over pre-split components (no Regex evaluation — the static, compiled Regex is used for parse-time validation only), mirroring the `WildcardDomain` approach. Per-dependency results are amortized by the existing `CachingTypeDependencyValidator` as before.
* Rule specificity: a placeholder counts like the corresponding wildcard (`[Name]` like `?`, `[Name*]` like `*`), reusing the existing edit-distance calculation.
* Parser routing: a specification containing `[` is parsed as `PlaceholderDomain` — after the Regex branch (character classes contain `[`), before the wildcard branch (`[Name*]` contains `*`).
* Validity checks throw `FormatException` at config load (consistent with `DomainSpecification`): unique names on `From`; every `To` placeholder must be bound on `From`; `[!Name]` must not refer to `[Name*]`; `[!Name*]` is invalid; no two adjacent multi-matching tokens (mirrors the `*.*` rule).
* `XmlConfigParser`: the `DependencyRule` construction is now wrapped in `TryAndReportError`, so rule-level validation errors are reported with line info, like side-level parse errors.

## Compatibility

* No behavior change for existing configs: specifications without `[` take exactly the previous code path.
* No new diagnostics, no config schema change (`From`/`To` are `xs:string`), no Roslyn API usage in the new code (roslyn4.0 and roslyn5.0 variants unaffected).

## Limitations (by design)

* With several possible capture splits (eg. `[A*].[B]`), the leftmost placeholder captures as few components as possible; no cross-side backtracking over alternative splits. A literal anchor between multi-matching tokens avoids ambiguity.
* `[Name*]` captures at least one component (a zero-component capture would produce an empty segment on substitution).

## Tests

Three new test classes (~86 cases): `PlaceholderDomainTests` (syntax validation, capture matching incl. backtracking, substitution, relevance, parser routing incl. Regex disambiguation), `DependencyRulePlaceholderTests` (capture transfer, negation, name-based binding, validity errors, equality/hash as dictionary key, regression for placeholder-free rules), `TypeDependencyValidatorPlaceholderTests` (end-to-end allow/disallow, visible members, most-specific rule selection).

## Suggested changelog entry

- [x] New: Named placeholders in dependency rules, eg. `<Allowed From="[Module].Services" To="[Module].Domain" />`. Placeholders capture on the `From` side and are referenced (`[Name]`) or negated (`[!Name]`) on the `To` side. See [Placeholders](doc/Help.md#placeholders).

Thanks for considering.